### PR TITLE
ubuntu-desktop: update mandatory tests

### DIFF
--- a/resolute/testsuites/Ubuntu Desktop/Mandatory/Install (auto-resize).md
+++ b/resolute/testsuites/Ubuntu Desktop/Mandatory/Install (auto-resize).md
@@ -1,101 +1,77 @@
+# Install (auto-resize)
 
-<p><em>Proceed in your native language if you wish. Instructions will remain in English.</em></p>
-<dl>
+* Boot up the image
+  - If you see the GRUB menu, select the "Try or install Ubuntu" option to boot into the live session.
 
+* Wait for the system to boot into the live session. The desktop installer should open automatically and play a welcome sound.
 
-<dt>Boot up the image</dt>
-  <dd>If you see the GRUB boot menu you should see the following:</dd>
-  <dd>
-     <ul>
-     <li>'Try or Install FAMILY'</li>
-     <li>'FAMILY (safe graphics)'</li>
-     <li>'OEM install (for manufacturers)'</li>
-     <li>'Test memory' (only on BIOS systems)</li>
-     </ul>
-  </dd>
+* You should see the "Choose your language" page.
+  - Pick your desired language. (The instructions will remain in English).
+  - Click "Next".
 
+* You should see the "Accessibility" page.
+  - Click through the options, (Seeing, Hearing, Typing, Pointing and clicking, Zoom) and make sure the drop down options are fully functional.
+  - Click "Next".
 
-<dt>Upon reaching the desktop environment, you should be greeted with the "Choose your language" screen.</dt>
-  <dd>Pick your desired language.</dd>
+* You should see the "Keyboard layout" page.
+  - Choose your desired layout.
+  - Click "Next".
 
+* You should see the "Connect to the internet" page.
+  - Use the UI to connect to a network.
+  - Click "Next".
 
-<dt>You should be greeted with a panel where you are prompted to set any of your needed or desired accessibility options.</dt>
-  <dd>Click through the options, (Seeing, Hearing, Typing, Pointing and clicking, Zoom) and make sure the drop down options are fully functional.</dd>
+* You should see the "Try or install Ubuntu" page.
+  - Click "Install Ubuntu".
 
+* You should see the "Type of installation" page.
+  - Select "Interactive installation".
+  - Click "Next".
 
-<dt>You're greeted with the 'Try or install FAMILY' slide. The 'FAMILY' logo should be on the left hand side.</dt>
-  <dd>Select "Install Ubuntu" to continue with the installation process, or "Try Ubuntu" to boot into a live session.</dd>
+* You should see the "Applications" page.
+  - Select "Default selection".
+  - Click "Next".
 
+* You should see the "Optimise your computer" page.
+  - Leave the checkboxes unchecked.
+  - Click "Next".
 
-<dt>You should be greeted with a slide asking you to confirm your keyboard layout.</dt>
-  <dd>Feel free to either select your desired layout, or use the auto-detect feature at the bottom.</dd>
-<dt>Proceed by clicking "Next"</dt>
+* You should see the "Disk setup" page.
+  - Select "Install Ubuntu alongside SYSTEM YY".
+  - Click "Next".
 
+* You should see the "Install Ubuntu alongside SYSTEM YY" page.
+  - Move the slider to adjust the partition sizes as desired.
+  - Click "Next".
 
-<dt>The 'Connect to a network' screen should now be displayed</dt>
-<dd>The screen should reflect the current status and display the following options (unless you're in a VM):</dd>
-  <dd>
-     <ul>
-     <li>Wired connection</li>
-     <li>Connect to a Wi-Fi network followed by a scrollable list of available APs, displaying an active one colored with a leading checkmark</li>
-     <li>Connect to a hidden Wi-Fi network</li>
-     <li>I don't want to connect to internet for now</li>
-     </ul>
-  </dd>
-<dd>If you ARE installing in a VM, you should check that the VM automatically has internet access. This is usually via a "wired connection".</dd>
-<dd>If you're testing a testcase that requires no internet access, make sure the install medium does not have internet access by configuring it properly in this slide.</dd>
-<dt>Click "Next"</dt>
+* You should see the "Encryption and file system" page.
+  - Select "No encryption".
+  - Click "Next".
 
+* You should see the "Create your account" page.
+  - Fill in the details for your user account.
+  - Click "Next".
 
-<dt>The 'Applications and updates' screen is displayed, listing normal and minimal installation, as well as options for installing updates, third party software and additional media formats.</dt>
-<dd>Select any options pertinent to the testcase - though "Default installation" is normally the desired option.</dd>
-<dt>Click "Next"</dt>
+* You should see the "Select your timezone" page.
+  - If your system is connected to the internet, verify that the timezone that was auto-detected is accurate.
+  - Click "Next".
 
+* You should see the "Ready to install" page.
+  - Check that the summary of the installation options you selected throughout the process is accurate.
+  - Click "Install".
 
-  <dd>The 'Installation type' screen is displayed</dd>
+* You should see a slideshow while the installation is taking place.
+  - Wait for the installation to complete.
 
+* You should see the "Installation complete" page.
+  - Click "Restart Now".
 
-<dt>Select 'Install FAMILY XX.XX alongside SYSTEM YY'</dt>
-    <dd>(SYSTEM YY is the name of the system already installed on disk (FAMILY 12.04, Windows 7, ...)</dd>
-<dt>Click on 'Continue'</dt>
-    <dd>The Screen Install FAMILY XX.XX alongside SYSTEM YY appears</dd>
-<dt>Note the drive selected on the Select drive list and the bar state</dt>
-<dd><strong>If the target drive has a free partition with sufficient free space, install will proceed without further partitioning intervention</strong></dd>
-    <dd>The drive corresponds to the drive on the chart (e.g /dev/sda) and the bar is divided</dd>
-<dt>Move the bar that separates the sections as appropriate</dt>
-    <dd>The slider bar can be set as appropriate</dd>
-<dt>Click on the 'Install Now' button</dt>
-  <dd>The 'Write changes to disk' screen is displayed, including the details of incoming partitions changes.</dd>
-<dt>Verify that the partitioning details make sense</dt>
-<dt>Click 'Start Installing'</dt>
+* Allow the machine to reboot.
 
+* You should see the login screen with the username you created during the installation process.
+  - Log in with the password you set during the installation process.
 
-<dt>You should be greeted with the "Set up your account" slide</dt>
-  <dd>Put in your desired user details.</dd>
+----
+**If all actions produce the expected results listed, please submit a `passed` result.**
 
-
-<dt>You should be greeted with the "Select your timezone" slide</dt>
-  <dd>If your system is connected to the internet, verify that the timezone that was auto-detected is accurate</dd>
-  <dd>Note that, if you're on a VPN, the timezone will be affected by this.</dd>
-<dt>Click 'Next'</dt>
-
-
-<dt>You should be greeted by the "Ready to install" slide.</dt>
-<dt>On this slide, the devices to be changed and the partition table is shown to the user.</dt>
-  <dd>Check that the devices listed and the partition table listed is accurate and representative of the install options you set earlier in the process.</dd>
-<dt>Click 'Next'</dt>
-
-
-<dt>Allow the machine to reboot</dt>
-  <dd>The system boots properly and loads into FAMILY showing username selected</dd>
-
-
-</dl>
-<p>If <strong>all</strong> actions produce the expected results described,
-  please <a href="results#add_result">submit</a> a 'passed' result.</p>
-<p>If <strong>any</strong> action fails, or produces an unexpected result,
-  please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include
-  the bug number when you <a href="results#add_result">submit</a> your
-  result.</p>
-
-
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/resolute/testsuites/Ubuntu Desktop/Mandatory/Install (entire disk with TPM encryption).md
+++ b/resolute/testsuites/Ubuntu Desktop/Mandatory/Install (entire disk with TPM encryption).md
@@ -1,101 +1,79 @@
+# Install (entire disk with TPM encryption)
 
-<p><em>Proceed in your native language if you wish. Instructions will remain in English.</em></p>
-<dl>
+In order to do full disk encryption with TPM, you either need to make sure you're using a piece of hardware that has TPM functionality, or you can install with a VM, making sure you have the correct options set to emulate a TPM backed system.
 
+* Boot up the image
+  - If you see the GRUB menu, select the "Try or install Ubuntu" option to boot into the live session.
 
-<dt>Boot up the image</dt>
-  <dd>If you see the GRUB boot menu you should see the following:</dd>
-  <dd>
-     <ul>
-     <li>'Try or Install FAMILY'</li>
-     <li>'FAMILY (safe graphics)'</li>
-     <li>'OEM install (for manufacturers)'</li>
-     <li>'Test memory' (only on BIOS systems)</li>
-     </ul>
-  </dd>
+* Wait for the system to boot into the live session. The desktop installer should open automatically and play a welcome sound.
 
+* You should see the "Choose your language" page.
+  - Pick your desired language. (The instructions will remain in English).
+  - Click "Next".
 
-<dt>Upon reaching the desktop environment, you should be greeted with the "Choose your language" screen.</dt>
-  <dd>Pick your desired language.</dd>
+* You should see the "Accessibility" page.
+  - Click through the options, (Seeing, Hearing, Typing, Pointing and clicking, Zoom) and make sure the drop down options are fully functional.
+  - Click "Next".
 
+* You should see the "Keyboard layout" page.
+  - Choose your desired layout.
+  - Click "Next".
 
-<dt>You should be greeted with a panel where you are prompted to set any of your needed or desired accessibility options.</dt>
-  <dd>Click through the options, (Seeing, Hearing, Typing, Pointing and clicking, Zoom) and make sure the drop down options are fully functional.</dd>
+* You should see the "Connect to the internet" page.
+  - Use the UI to connect to a network.
+  - Click "Next".
 
+* You should see the "Try or install Ubuntu" page.
+  - Click "Install Ubuntu".
 
-<dt>You're greeted with the 'Try or install FAMILY' slide. The 'FAMILY' logo should be on the left hand side.</dt>
-  <dd>Select "Install Ubuntu" to continue with the installation process, or "Try Ubuntu" to boot into a live session.</dd>
+* You should see the "Type of installation" page.
+  - Select "Interactive installation".
+  - Click "Next".
 
+* You should see the "Applications" page.
+  - Select "Default selection".
+  - Click "Next".
 
-<dt>You should be greeted with a slide asking you to confirm your keyboard layout.</dt>
-  <dd>Feel free to either select your desired layout, or use the auto-detect feature at the bottom.</dd>
-<dt>Proceed by clicking "Next"</dt>
+* You should see the "Optimise your computer" page.
+  - Leave the checkboxes unchecked.
+  - Click "Next".
 
+* You should see the "Disk setup" page.
+  - Select "Erase disk and install Ubuntu".
+  - Click "Next".
 
-<dt>The 'Connect to a network' screen should now be displayed</dt>
-<dd>The screen should reflect the current status and display the following options (unless you're in a VM):</dd>
-  <dd>
-     <ul>
-     <li>Wired connection</li>
-     <li>Connect to a Wi-Fi network followed by a scrollable list of available APs, displaying an active one colored with a leading checkmark</li>
-     <li>Connect to a hidden Wi-Fi network</li>
-     <li>I don't want to connect to internet for now</li>
-     </ul>
-  </dd>
-<dd>If you ARE installing in a VM, you should check that the VM automatically has internet access. This is usually via a "wired connection".</dd>
-<dd>If you're testing a testcase that requires no internet access, make sure the install medium does not have internet access by configuring it properly in this slide.</dd>
-<dt>Click "Next"</dt>
+* You should see the "Encryption and file system" page.
+  - Select "Use hardware-backed encryption".
+  - Click "Next".
 
+* You should see the "Create your account" page.
+  - Fill in the details for your user account.
+  - Click "Next".
 
-<dt>The 'Applications and updates' screen is displayed, listing normal and minimal installation, as well as options for installing updates, third party software and additional media formats.</dt>
-<dd>Select any options pertinent to the testcase - though "Default installation" is normally the desired option.</dd>
-<dt>Click "Next"</dt>
+* You should see the "Select your timezone" page.
+  - If your system is connected to the internet, verify that the timezone that was auto-detected is accurate.
+  - Click "Next".
 
+* You should see the "Ready to install" page.
+  - Check that the summary of the installation options you selected throughout the process is accurate.
+  - Click "Install".
 
-  <dd>The 'Installation type' screen is displayed</dd>
+* You should see a slideshow while the installation is taking place.
+  - Wait for the installation to complete.
 
+* You should see the "Installation complete" page.
+  - Click "Restart Now".
 
-<dt>Click on "Advanced features"</dt>
-  <dd>Click on the tickbox for "Enhanced secure-boot"</dd>
-  <dd>Click on the tickbox for Hardware-backed full disk encryption</dd>
-  <dd>Click "Ok"</dd>
-<dt>Click Continue</dt>
+* Allow the machine to reboot.
 
+* You should see the login screen with the username you created during the installation process.
+  - Log in with the password you set during the installation process.
 
-<dt>In order to do full disk encryption with TPM, you either need to make sure you're using a piece of hardware that has TPM functionality, or you can install with a VM, making sure you have the correct options set to emulate a TPM backed system.</dt>
+* Open a terminal, run the following commands and verify their output:
+  - `snap list`, and check that the `pc-kernel` package is installed.
+  - `sudo apt install linux-image-generic`, and you should get a response which includes this message: `boot-managed-by-snapd : Conflicts: linux-image`.
 
+----
+**If all actions produce the expected results listed, please submit a `passed` result.**
 
-<dt>You should be greeted with the "Set up your account" slide</dt>
-  <dd>Put in your desired user details.</dd>
-
-
-<dt>You should be greeted with the "Select your timezone" slide</dt>
-  <dd>If your system is connected to the internet, verify that the timezone that was auto-detected is accurate</dd>
-  <dd>Note that, if you're on a VPN, the timezone will be affected by this.</dd>
-<dt>Click 'Next'</dt>
-
-
-<dt>You should be greeted by the "Ready to install" slide.</dt>
-<dt>On this slide, the devices to be changed and the partition table is shown to the user.</dt>
-  <dd>Check that the devices listed and the partition table listed is accurate and representative of the install options you set earlier in the process.</dd>
-<dt>Click 'Next'</dt>
-
-
-<dt>Allow the machine to reboot</dt>
-  <dd>The system boots properly and loads into FAMILY showing username selected</dd>
-
-
-<dt>After rebooting, log in to the installed system and run `snap list`, and check that the `pc-kernel` package is installed.</dt>
-<dt>Open up a terminal window, and try to run this command: `sudo apt install linux-image-generic`.</dt>
-  <dd>You should get a response which includes this message: `boot-managed-by-snapd : Conflicts: linux-image`</dd>
-
-
-</dl>
-<p>If <strong>all</strong> actions produce the expected results described,
-  please <a href="results#add_result">submit</a> a 'passed' result.</p>
-<p>If <strong>any</strong> action fails, or produces an unexpected result,
-  please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include
-  the bug number when you <a href="results#add_result">submit</a> your
-  result.</p>
-
-
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/resolute/testsuites/Ubuntu Desktop/Mandatory/Install (entire disk with ZFS plus encryption).md
+++ b/resolute/testsuites/Ubuntu Desktop/Mandatory/Install (entire disk with ZFS plus encryption).md
@@ -1,171 +1,170 @@
+# Install (entire disk with ZFS plus encryption)
 
-<p><em>Proceed in your native language if you wish. Instructions will remain in English.</em></p>
-<dl>
+* Boot up the image
+  - If you see the GRUB menu, select the "Try or install Ubuntu" option to boot into the live session.
 
-<dd><p><strong>This test involves installing a fresh system with zfs + encryption, then breaking the system in a post-install test step. If the system you are installing on is important to you, and you want to preserve the zfs+encryption installed system, do not do this test.</strong></dd>
+* Wait for the system to boot into the live session. The desktop installer should open automatically and play a welcome sound.
 
-<dt>Boot up the image</dt>
-    <dd>If you see the GRUB boot menu you should see the following:</dd>
-    <dd>
-       <ul>
-       <li>'Try or Install FAMILY'</li>
-       <li>'FAMILY (safe graphics)'</li>
-       <li>'OEM install (for manufacturers)'</li>
-       <li>'Test memory' (only on BIOS systems)</li>
-       </ul>
-    </dd>
-    <dd>The system boots properly and loads the installer displaying the Welcome dialog with language selection and 'Try FAMILY' and 'Install FAMILY' buttons</dd>
-<dt>Click on the release notes hyperlink to confirm that a browser launches and you are taken to the release notes discourse page.</dt>
-<dt>Click on the Install FAMILY button</dt>
-    <dd>The 'Keyboard layout' screen appears</dd>
-    <dd>The proposed keyboard corresponds with your keyboard</dd>
-<dt>Select your keyboard layout and click on Continue</dt>
-    <dd>The 'Updates and other software' screen is displayed</dd>
-<dt>On the screen 'Updates and other software', note the availability of the following components</dt>
-    <dd>Available options should represent the state of your system accurately</dd>
-    <dd>For Mantic and later releases, the default install is a minimal install. Releases before Mantic the default is a 'full' install, complete with other apps a user might want. The new, default, install does not include these add-ons.</dd>
-    <dd>
-        <ul>
-            <li>(If network is available) 'Download updates while installing FAMILY'</li>
-            <li>(If on a 'laptop') 'Is plugged to a power source'</li>
-            <li>'Install third-party software...' option available</li>
-        </ul>
-    </dd>
-<dt>Click on the Continue button</dt>
-    <dd>The 'Installation type' screen is displayed</dd>
+* You should see the "Choose your language" page.
+  - Pick your desired language. (The instructions will remain in English).
+  - Click "Next".
 
+* You should see the "Accessibility" page.
+  - Click through the options, (Seeing, Hearing, Typing, Pointing and clicking, Zoom) and make sure the drop down options are fully functional.
+  - Click "Next".
 
-<dt>Note the state of the 'Erase disk and install FAMILY' radio button</dt>
-    <dd>The 'Erase disk and install FAMILY' radio button is selected and the 'Advanced features' button is active</dd>
-    <dt>Click on the 'Advanced features...' button</dt>
-    <dd>The 'Advanced Features' dialog is displayed</dd>
-<dt>Select 'Erase disk and use ZFS'</dt>
-    <dd>'Erase disk and use ZFS' is selected</dd>
-    <dd>Check the tickbox for 'Encrypt the new Ubuntu installation for security'</dd>
-<dt>Click on the 'OK' button</dt>
-    <dd>The dialog closes and 'ZFS selected' is displayed next to the 'Advanced features...' button</dd>
-<dt>Click Continue</dt>
-<dt>The "Choose a security key" slide opens</dt>
-    <dd>Enter your desired security key</dd>
-<dt>Click on the 'Install Now' button</dt>
-    <dd>'Write the changes to disks' dialogue appears</dd>
-<dt>Click Continue</dt>
-<dt>If there is only one hard disk, skip to step 18 (On the 'Where are you?' screen...). Otherwise, on the 'Installation type' screen verify that the drive selected on the Select drive list corresponds to the drive on the chart (e.g /dev/sda)</dt>
-    <dd>Selected drive is displayed on the chart</dd>
-<dt>Verify that the full drive space is allocated</dt>
-    <dd>Full drive space is allocated for installation</dd>
-<dt>Click on the Install Now button</dt>
-    <dd>The 'Where are you?' screen is displayed</dd>
+* You should see the "Keyboard layout" page.
+  - Choose your desired layout.
+  - Click "Next".
 
+* You should see the "Connect to the internet" page.
+  - Use the UI to connect to a network.
+  - Click "Next".
 
-<dt>If your system is connected to the network, note the preselected timezone corresponds with your timezone and the city indicated in the text box</dt>
-    <dd>The timezone and city displayed match your timezone and a major city from your area</dd>
-<dt>Select your timezone, and click on the Continue button</dt>
-    <dd>The 'Who are you?' screen appears</dd>
-<dt>Input your initial user details and password <em>admin can not be used - it is a dedicated Linux User</em></dt>
-    <dd>'Require my password to log in' is shown and selected or if 'Log in automatically' and 'require my password to log in' are shown then 'Require my password to login' is selected. If just 'Require my password to log in' is shown, having it off is the equivalent of having 'Log in automatically' on.</dd>
-    <dd>Name, username and password are accepted.</dd>
-    <dd>Continue button becomes available</dd>
-<dt>Press Continue</dt>
-    <dd>The 'Welcome to FAMILY' slide is displayed</dd>
-    <dd>The slideshow is entirely in your language</dd>
-<dt>Wait for the installer to finish</dt>
-    <dd>An 'Installation Complete' dialog appears</dd>
-<dt>Click the 'Restart Now' button</dt>
-    <dd>GUI is shut down, a prompt to remove media and press Enter appears</dd>
-<dt>Remove the disc and press enter</dt>
-    <dd>The machine is rebooted</dd>
+* You should see the "Try or install Ubuntu" page.
+  - Click "Install Ubuntu".
 
+* You should see the "Type of installation" page.
+  - Select "Interactive installation".
+  - Click "Next".
 
-<dt>Allow the machine to reboot</dt>
-    <dd>The system boots properly and your passphrase works</dd>
-    <dd>The system loads into FAMILY showing username selected</dd>
-    <dd>Upon login, open a terminal, run the following commands and verify it matches the output</dd>
-    <dd><code>$ zfs mount | sort
-        bpool/BOOT/ubuntu_UUID        /boot
-        rpool/ROOT/ubuntu_UUID        /
-        rpool/ROOT/ubuntu_UUID/srv    /srv
-        rpool/ROOT/ubuntu_UUID/usr/local  /usr/local
-        rpool/ROOT/ubuntu_UUID/var/games  /var/games
-        rpool/ROOT/ubuntu_UUID/var/lib/AccountsService  /var/lib/AccountsService
-        rpool/ROOT/ubuntu_UUID/var/lib/apt  /var/lib/apt
-        rpool/ROOT/ubuntu_UUID/var/lib/dpkg  /var/lib/dpkg
-        rpool/ROOT/ubuntu_UUID/var/lib/NetworkManager  /var/lib/NetworkManager
-        rpool/ROOT/ubuntu_UUID/var/lib  /var/lib
-        rpool/ROOT/ubuntu_UUID/var/log  /var/log
-        rpool/ROOT/ubuntu_UUID/var/mail  /var/mail
-        rpool/ROOT/ubuntu_UUID/var/snap  /var/snap
-        rpool/ROOT/ubuntu_UUID/var/spool  /var/spool
-        rpool/ROOT/ubuntu_UUID/var/www  /var/www
-        rpool/USERDATA/root_0y7dio      /root
-        rpool/USERDATA/u_0y7dio         /home/u
-    </code></dd>
-<dt>Run the lsblk command and check for this line in the output:</dt>
-  <dd>cryptoswap   252:1    0   2.6G  0 crypt [SWAP]</dd>
-<dt>Run the following command to place a file under ~:</dt>
-  <dd>echo "hello" &gt; /home/$USER/hello</dd>
-  <dd>We're going to check for this file in a later part of this test case.</dd>
+* You should see the "Applications" page.
+  - Select "Default selection".
+  - Click "Next".
 
+* You should see the "Optimise your computer" page.
+  - Leave the checkboxes unchecked.
+  - Click "Next".
 
-<dt>Shut down the installed system.</dt>
-<dt>Using the same .iso, boot into the iso using the disk that you just completed the installation on.</dt>
-<dt>Go through the grub menu and instead of installing, select "Try Ubuntu".</dt>
-<dt>Open a terminal window, and enter the following:</dt>
-    <dd>sudo su</dd>
-    <dd>fdisk -l /dev/$disk # Where $disk is the disk you completed the install on.</dd>
-<dt>The output should include something similar to the following:</dt>
-    <dd><code>/dev/vda1      2048     4095     2048    1M BIOS boot
-              /dev/vda2      4096  1054719  1050624  513M EFI System
-              /dev/vda3   1054720  9037823  7983104  3.8G Linux swap
-              /dev/vda4   9037824 13178879  4141056    2G Solaris boot
-              /dev/vda5  13178880 83884031 70705152 33.7G Solaris root</code></dd>
-    <dd>For the rest of this testcase, we will use vda in place of $disk.</dd>
-<dt>Check for the zfs pool names:</dt>
-    <dd>blkid /dev/vda*</dd>
-    <dd><code>/dev/vda: PTUUID="7dd06581-4867-4632-9a90-23d9c472b039" PTTYPE="gpt"
-              /dev/vda1: PARTUUID="c061c581-06c1-43e2-8680-d353771bf341"
-              /dev/vda2: UUID="2748-996B" BLOCK_SIZE="512" TYPE="vfat" PARTLABEL="EFI System Partition" PARTUUID="f7c29e7e-687f-4cbb-a1a1-f8876f809a64"
-              /dev/vda3: UUID="8c1d6471-1f90-4212-8fbd-097a9a9ad909" TYPE="crypto_LUKS" PARTUUID="8ff61492-9bda-40fe-94a8-7d6fe4d220cb"
-              /dev/vda4: LABEL="bpool" UUID="8851209407646287070" UUID_SUB="1631837207961890120" BLOCK_SIZE="4096" TYPE="zfs_member" PARTUUID="8b8b8818-cc94-42bd-b23d-cf7c9e9b73ff"
-              /dev/vda5: LABEL="rpool" UUID="4519996901618382696" UUID_SUB="8860607139843727357" BLOCK_SIZE="4096" TYPE="zfs_member" PARTUUID="5cc65ba9-8ef4-475c-a107-cc130a9be1be"</code></dd>
-    <dd>Here, the zfs pool names are the labels of the drives of TYPE "zfs_member". So in this case, the zfs pools are "bpool" and "rpool".</dd>
-<dt>Now, we will import the pool of the root partition:</dt>
-    <dd>zpool import rpool</dd>
-<dt>Check the output of the following command to see that rpool is imported:</dt>
-    <dd>zpool status -v</dd>
-<dt>After entering the following command, enter your security key in the prompt:</dt>
-    <dd>cryptsetup luksOpen /dev/zvol/rpool/keystore keystore</dd>
-<dt>Mount the keystore:</dt>
-    <dd>mkdir /mnt/keystore</dd>
-    <dd>mount /dev/mapper/keystore /mnt/keystore</dd>
-<dt>Copy the key to necessary location:</dt>
-    <dd>mkdir -p /run/keystore/rpool</dd>
-    <dd>cp -b /mnt/keystore/system.key /run/keystore/rpool</dd>
-<dt>Make the root pool mountable:</dt>
-    <dd>zfs set canmount=on rpool</dd>
-<dt>Load the zfs key:</dt>
-    <dd>zfs load-key rpool</dd>
-<dt>Check for the pool associated with the userdata:</dt>
-    <dd>zfs list -o name,type,keylocation</dd>
-<dt>You want to find a line in the output of the above command in this format:</dt>
-    <dd>$poolname/USERDATA/$username_$hash</dd>
-    <dd>For example: rpool/USERDATA/tim_aqj46w</dd>
-<dt>Set mountpoint for USERDATA:</dt>
-    <dd>mkdir -p /mnt/rpool/USERDATA/tim_aqj46w</dd>
-    <dd>zfs set mountpoint=/mnt/rpool/USERDATA/tim_aqj46w rpool/USERDATA/tim_aqj46w</dd>
-<dt>Mount the pool:</dt>
-    <dd>zfs mount -a</dd>
-<dt>Check for the test file we made earlier, for example:</dt>
-    <dd>cat /mnt/rpool/USERDATA/tim_aqj46w/hello</dd>
-    <dd>The output should be "hello"</dd>
+* You should see the "Disk setup" page.
+  - Select "Erase disk and install Ubuntu".
+  - Click "Next".
 
+* You should see the "Encryption and file system" page.
+  - Click on "Advanced opttions".
+  - Select "Encrypt with a passphrase using ZFS".
+  - Click "Next".
 
-</dl>
-<p>If <strong>all</strong> actions produce the expected results described,
-  please <a href="results#add_result">submit</a> a 'passed' result.</p>
-<p>If <strong>any</strong> action fails, or produces an unexpected result,
-  please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include
-  the bug number when you <a href="results#add_result">submit</a> your
-  result.</p>
+* You should see the "Set an encryption passphrase" page.
+  - Enter your desired passphrase.
+  - Click "Next".
 
+* You should see the "Create your account" page.
+  - Fill in the details for your user account.
+  - Click "Next".
 
+* You should see the "Select your timezone" page.
+  - If your system is connected to the internet, verify that the timezone that was auto-detected is accurate.
+  - Click "Next".
+
+* You should see the "Ready to install" page.
+  - Check that the summary of the installation options you selected throughout the process is accurate.
+  - Click "Install".
+
+* You should see a slideshow while the installation is taking place.
+  - Wait for the installation to complete.
+
+* You should see the "Installation complete" page.
+  - Click "Restart Now".
+
+* Allow the machine to reboot.
+
+* You should see the login screen with the username you created during the installation process.
+  - Log in with the password you set during the installation process.
+
+* Open a terminal, run the following commands and verify their output:
+    - `zfs mount | sort`
+      ```
+      bpool/BOOT/ubuntu_UUID        /boot
+      rpool/ROOT/ubuntu_UUID        /
+      rpool/ROOT/ubuntu_UUID/srv    /srv
+      rpool/ROOT/ubuntu_UUID/usr/local  /usr/local
+      rpool/ROOT/ubuntu_UUID/var/games  /var/games
+      rpool/ROOT/ubuntu_UUID/var/lib/AccountsService  /var/lib/AccountsService
+      rpool/ROOT/ubuntu_UUID/var/lib/apt  /var/lib/apt
+      rpool/ROOT/ubuntu_UUID/var/lib/dpkg  /var/lib/dpkg
+      rpool/ROOT/ubuntu_UUID/var/lib/NetworkManager  /var/lib/NetworkManager
+      rpool/ROOT/ubuntu_UUID/var/lib  /var/lib
+      rpool/ROOT/ubuntu_UUID/var/log  /var/log
+      rpool/ROOT/ubuntu_UUID/var/mail  /var/mail
+      rpool/ROOT/ubuntu_UUID/var/snap  /var/snap
+      rpool/ROOT/ubuntu_UUID/var/spool  /var/spool
+      rpool/ROOT/ubuntu_UUID/var/www  /var/www
+      rpool/USERDATA/root_0y7dio      /root
+      rpool/USERDATA/u_0y7dio         /home/u
+      ```
+
+    - `lsblk`, and check for this line in the output:
+      ```
+      cryptoswap   252:1    0   2.6G  0 crypt [SWAP]
+      ```
+
+* Run the following command to create a test file in the home directory:
+    - `echo "hello" > /home/$USER/hello && sync`
+    - We're going to check for this file in a later part of this test case.
+
+* Shut down the installed system.
+
+* Using the same .iso, boot into the iso using the disk that you just completed the installation on.
+
+* Go through the grub menu and instead of installing, select "Try Ubuntu".
+
+* Open a terminal window, and run the following commands:
+    - `sudo su`
+    - `fdisk -l /dev/$disk`,  Where `$disk` is the disk you completed the install on.
+    - The output should include something similar to the following:
+        ```
+        /dev/vda1      2048     4095     2048    1M BIOS boot
+        /dev/vda2      4096  1054719  1050624  513M EFI System
+        /dev/vda3   1054720  9037823  7983104  3.8G Linux swap
+        /dev/vda4   9037824 13178879  4141056    2G Solaris boot
+        /dev/vda5  13178880 83884031 70705152 33.7G Solaris root
+        ```
+    - For the rest of this testcase, we will use `vda` in place of `$disk`.
+
+* Check for the zfs pool names:
+    - `blkid /dev/vda*`
+        ```
+        /dev/vda: PTUUID="7dd06581-4867-4632-9a90-23d9c472b039" PTTYPE="gpt"
+        /dev/vda1: PARTUUID="c061c581-06c1-43e2-8680-d353771bf341"
+        /dev/vda2: UUID="2748-996B" BLOCK_SIZE="512" TYPE="vfat" PARTLABEL="EFI System Partition" PARTUUID="f7c29e7e-687f-4cbb-a1a1-f8876f809a64"
+        /dev/vda3: UUID="8c1d6471-1f90-4212-8fbd-097a9a9ad909" TYPE="crypto_LUKS" PARTUUID="8ff61492-9bda-40fe-94a8-7d6fe4d220cb"
+        /dev/vda4: LABEL="bpool" UUID="8851209407646287070" UUID_SUB="1631837207961890120" BLOCK_SIZE="4096" TYPE="zfs_member" PARTUUID="8b8b8818-cc94-42bd-b23d-cf7c9e9b73ff"
+        /dev/vda5: LABEL="rpool" UUID="4519996901618382696" UUID_SUB="8860607139843727357" BLOCK_SIZE="4096" TYPE="zfs_member" PARTUUID="5cc65ba9-8ef4-475c-a107-cc130a9be1be"
+        ```
+    - Here, the zfs pool names are the labels of the drives of TYPE `zfs_member`. So in this case, the zfs pools are `bpool` and `rpool`.
+
+* Now, we will import the pool of the root partition:
+    - `zpool import rpool`
+* Check the output of the following command to see that rpool is imported: 
+    - `zpool status -v`
+* After entering the following command, enter your security key in the prompt:
+    - `cryptsetup luksOpen /dev/zvol/rpool/keystore keystore`
+* Mount the keystore:
+    - `mkdir /mnt/keystore`
+    - `mount /dev/mapper/keystore /mnt/keystore`
+* Copy the key to necessary location:
+    - `mkdir -p /run/keystore/rpool`
+    - `cp -b /mnt/keystore/system.key /run/keystore/rpool`
+* Make the root pool mountable:
+    - `zfs set canmount=on rpool`
+* Load the zfs key:
+    - `zfs load-key rpool`
+* Check for the pool associated with the userdata:
+    - `zfs list -o name,type,keylocation`
+* You want to find a line in the output of the above command in this format:
+    - `$poolname/USERDATA/$username_$hash`
+    - For example: `rpool/USERDATA/tim_aqj46w`
+* Set mountpoint for USERDATA:
+    - `mkdir -p /mnt/rpool/USERDATA/tim_aqj46w`
+    - `zfs set mountpoint=/mnt/rpool/USERDATA/tim_aqj46w rpool/USERDATA/tim_aqj46w`
+* Mount the pool:
+    - `zfs mount -a`
+* Check for the test file we made earlier, for example:
+    - `cat /mnt/rpool/USERDATA/tim_aqj46w/hello`
+    - The output should be "hello"
+
+----
+**If all actions produce the expected results listed, please submit a `passed` result.**
+
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/resolute/testsuites/Ubuntu Desktop/Mandatory/Install (entire disk with ZFS).md
+++ b/resolute/testsuites/Ubuntu Desktop/Mandatory/Install (entire disk with ZFS).md
@@ -1,125 +1,96 @@
+# Install (entire disk with ZFS)
 
-<p><em>Proceed in your native language if you wish. Instructions will remain in English.</em></p>
-<dl>
+* Boot up the image
+  - If you see the GRUB menu, select the "Try or install Ubuntu" option to boot into the live session.
 
+* Wait for the system to boot into the live session. The desktop installer should open automatically and play a welcome sound.
 
-<dt>Boot up the image</dt>
-  <dd>If you see the GRUB boot menu you should see the following:</dd>
-  <dd>
-     <ul>
-     <li>'Try or Install FAMILY'</li>
-     <li>'FAMILY (safe graphics)'</li>
-     <li>'OEM install (for manufacturers)'</li>
-     <li>'Test memory' (only on BIOS systems)</li>
-     </ul>
-  </dd>
+* You should see the "Choose your language" page.
+  - Pick your desired language. (The instructions will remain in English).
+  - Click "Next".
 
+* You should see the "Accessibility" page.
+  - Click through the options, (Seeing, Hearing, Typing, Pointing and clicking, Zoom) and make sure the drop down options are fully functional.
+  - Click "Next".
 
-<dt>Upon reaching the desktop environment, you should be greeted with the "Choose your language" screen.</dt>
-  <dd>Pick your desired language.</dd>
+* You should see the "Keyboard layout" page.
+  - Choose your desired layout.
+  - Click "Next".
 
+* You should see the "Connect to the internet" page.
+  - Use the UI to connect to a network.
+  - Click "Next".
 
-<dt>You should be greeted with a panel where you are prompted to set any of your needed or desired accessibility options.</dt>
-  <dd>Click through the options, (Seeing, Hearing, Typing, Pointing and clicking, Zoom) and make sure the drop down options are fully functional.</dd>
+* You should see the "Try or install Ubuntu" page.
+  - Click "Install Ubuntu".
 
+* You should see the "Type of installation" page.
+  - Select "Interactive installation".
+  - Click "Next".
 
-<dt>You're greeted with the 'Try or install FAMILY' slide. The 'FAMILY' logo should be on the left hand side.</dt>
-  <dd>Select "Install Ubuntu" to continue with the installation process, or "Try Ubuntu" to boot into a live session.</dd>
+* You should see the "Applications" page.
+  - Select "Default selection".
+  - Click "Next".
 
+* You should see the "Optimise your computer" page.
+  - Leave the checkboxes unchecked.
+  - Click "Next".
 
-<dt>You should be greeted with a slide asking you to confirm your keyboard layout.</dt>
-  <dd>Feel free to either select your desired layout, or use the auto-detect feature at the bottom.</dd>
-<dt>Proceed by clicking "Next"</dt>
+* You should see the "Disk setup" page.
+  - Select "Erase disk and install Ubuntu".
+  - Click "Next".
 
+* You should see the "Encryption and file system" page.
+  - Click on "Advanced opttions".
+  - Select "Use ZFS without encryption".
+  - Click "Next".
 
-<dt>The 'Connect to a network' screen should now be displayed</dt>
-<dd>The screen should reflect the current status and display the following options (unless you're in a VM):</dd>
-  <dd>
-     <ul>
-     <li>Wired connection</li>
-     <li>Connect to a Wi-Fi network followed by a scrollable list of available APs, displaying an active one colored with a leading checkmark</li>
-     <li>Connect to a hidden Wi-Fi network</li>
-     <li>I don't want to connect to internet for now</li>
-     </ul>
-  </dd>
-<dd>If you ARE installing in a VM, you should check that the VM automatically has internet access. This is usually via a "wired connection".</dd>
-<dd>If you're testing a testcase that requires no internet access, make sure the install medium does not have internet access by configuring it properly in this slide.</dd>
-<dt>Click "Next"</dt>
+* You should see the "Create your account" page.
+  - Fill in the details for your user account.
+  - Click "Next".
 
+* You should see the "Select your timezone" page.
+  - If your system is connected to the internet, verify that the timezone that was auto-detected is accurate.
+  - Click "Next".
 
-<dt>The 'Applications and updates' screen is displayed, listing normal and minimal installation, as well as options for installing updates, third party software and additional media formats.</dt>
-<dd>Select any options pertinent to the testcase - though "Default installation" is normally the desired option.</dd>
-<dt>Click "Next"</dt>
+* You should see the "Ready to install" page.
+  - Check that the summary of the installation options you selected throughout the process is accurate.
+  - Click "Install".
 
+* You should see a slideshow while the installation is taking place.
+  - Wait for the installation to complete.
 
-  <dd>The 'Installation type' screen is displayed</dd>
+* You should see the "Installation complete" page.
+  - Click "Restart Now".
 
+* Allow the machine to reboot.
 
-<dt>Note the state of the 'Erase disk and install FAMILY' radio button</dt>
-    <dd>The 'Erase disk and install FAMILY' radio button is selected and the 'Advanced features' button is active</dd>
-    <dt>Click on the 'Advanced features...' button</dt>
-    <dd>The 'Advanced Features' dialog is displayed</dd>
-<dt>Select 'Erase disk and use ZFS'</dt>
-    <dd>'Erase disk and use ZFS' is selected</dd>
-<dt>Click on the 'OK' button</dt>
-    <dd>The dialog closes and 'ZFS selected' is displayed next to the 'Advanced features...' button</dd>
-<dt>Click on the 'Install Now' button</dt>
-    <dd>'Write the changes to disks' dialogue appears</dd>
-<dt>Click Continue</dt>
-<dt>If there is only one hard disk, skip to the 'Where are you?' screen. Otherwise, on the 'Installation type' screen verify that the drive selected on the Select drive list corresponds to the drive on the chart (e.g /dev/sda)</dt>
-    <dd>Selected drive is displayed on the chart</dd>
-<dt>Verify that the full drive space is allocated</dt>
-    <dd>Full drive space is allocated for installation</dd>
-<dt>Click on the Next button</dt>
+* You should see the login screen with the username you created during the installation process.
+  - Log in with the password you set during the installation process.
 
+* Open a terminal, run the following commands and verify their output:
+    - `zfs mount | sort`
+      ```
+      bpool/BOOT/ubuntu_UUID        /boot
+      rpool/ROOT/ubuntu_UUID        /
+      rpool/ROOT/ubuntu_UUID/srv    /srv
+      rpool/ROOT/ubuntu_UUID/usr/local  /usr/local
+      rpool/ROOT/ubuntu_UUID/var/games  /var/games
+      rpool/ROOT/ubuntu_UUID/var/lib/AccountsService  /var/lib/AccountsService
+      rpool/ROOT/ubuntu_UUID/var/lib/apt  /var/lib/apt
+      rpool/ROOT/ubuntu_UUID/var/lib/dpkg  /var/lib/dpkg
+      rpool/ROOT/ubuntu_UUID/var/lib/NetworkManager  /var/lib/NetworkManager
+      rpool/ROOT/ubuntu_UUID/var/lib  /var/lib
+      rpool/ROOT/ubuntu_UUID/var/log  /var/log
+      rpool/ROOT/ubuntu_UUID/var/mail  /var/mail
+      rpool/ROOT/ubuntu_UUID/var/snap  /var/snap
+      rpool/ROOT/ubuntu_UUID/var/spool  /var/spool
+      rpool/ROOT/ubuntu_UUID/var/www  /var/www
+      rpool/USERDATA/root_0y7dio      /root
+      rpool/USERDATA/u_0y7dio         /home/u
+      ```
 
-<dt>You should be greeted with the "Set up your account" slide</dt>
-  <dd>Put in your desired user details.</dd>
+----
+**If all actions produce the expected results listed, please submit a `passed` result.**
 
-
-<dt>You should be greeted with the "Select your timezone" slide</dt>
-  <dd>If your system is connected to the internet, verify that the timezone that was auto-detected is accurate</dd>
-  <dd>Note that, if you're on a VPN, the timezone will be affected by this.</dd>
-<dt>Click 'Next'</dt>
-
-
-<dt>You should be greeted by the "Ready to install" slide.</dt>
-<dt>On this slide, the devices to be changed and the partition table is shown to the user.</dt>
-  <dd>Check that the devices listed and the partition table listed is accurate and representative of the install options you set earlier in the process.</dd>
-<dt>Click 'Next'</dt>
-
-
-<dt>Allow the machine to reboot</dt>
-    <dd>The system boots properly</dd>
-    <dd>The system loads into FAMILY showing username selected</dd>
-    <dd>Upon login, open a terminal, run the following commands and verify it matches the output</dd>
-    <dd><code>$ zfs mount | sort
-        bpool/BOOT/ubuntu_UUID        /boot
-        rpool/ROOT/ubuntu_UUID        /
-        rpool/ROOT/ubuntu_UUID/srv    /srv
-        rpool/ROOT/ubuntu_UUID/usr/local  /usr/local
-        rpool/ROOT/ubuntu_UUID/var/games  /var/games
-        rpool/ROOT/ubuntu_UUID/var/lib/AccountsService  /var/lib/AccountsService
-        rpool/ROOT/ubuntu_UUID/var/lib/apt  /var/lib/apt
-        rpool/ROOT/ubuntu_UUID/var/lib/dpkg  /var/lib/dpkg
-        rpool/ROOT/ubuntu_UUID/var/lib/NetworkManager  /var/lib/NetworkManager
-        rpool/ROOT/ubuntu_UUID/var/lib  /var/lib
-        rpool/ROOT/ubuntu_UUID/var/log  /var/log
-        rpool/ROOT/ubuntu_UUID/var/mail  /var/mail
-        rpool/ROOT/ubuntu_UUID/var/snap  /var/snap
-        rpool/ROOT/ubuntu_UUID/var/spool  /var/spool
-        rpool/ROOT/ubuntu_UUID/var/www  /var/www
-        rpool/USERDATA/root_0y7dio      /root
-        rpool/USERDATA/u_0y7dio         /home/u
-    </code></dd>
-
-
-</dl>
-<p>If <strong>all</strong> actions produce the expected results described,
-  please <a href="results#add_result">submit</a> a 'passed' result.</p>
-<p>If <strong>any</strong> action fails, or produces an unexpected result,
-  please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include
-  the bug number when you <a href="results#add_result">submit</a> your
-  result.</p>
-
-
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/resolute/testsuites/Ubuntu Desktop/Mandatory/Install (entire disk).md
+++ b/resolute/testsuites/Ubuntu Desktop/Mandatory/Install (entire disk).md
@@ -1,90 +1,73 @@
+# Install (entire disk)
 
-<p><em>Proceed in your native language if you wish. Instructions will remain in English.</em></p>
-<dl>
+* Boot up the image
+  - If you see the GRUB menu, select the "Try or install Ubuntu" option to boot into the live session.
 
+* Wait for the system to boot into the live session. The desktop installer should open automatically and play a welcome sound.
 
-<dt>Boot up the image</dt>
-  <dd>If you see the GRUB boot menu you should see the following:</dd>
-  <dd>
-     <ul>
-     <li>'Try or Install FAMILY'</li>
-     <li>'FAMILY (safe graphics)'</li>
-     <li>'OEM install (for manufacturers)'</li>
-     <li>'Test memory' (only on BIOS systems)</li>
-     </ul>
-  </dd>
+* You should see the "Choose your language" page.
+  - Pick your desired language. (The instructions will remain in English).
+  - Click "Next".
 
+* You should see the "Accessibility" page.
+  - Click through the options, (Seeing, Hearing, Typing, Pointing and clicking, Zoom) and make sure the drop down options are fully functional.
+  - Click "Next".
 
-<dt>Upon reaching the desktop environment, you should be greeted with the "Choose your language" screen.</dt>
-  <dd>Pick your desired language.</dd>
+* You should see the "Keyboard layout" page.
+  - Choose your desired layout.
+  - Click "Next".
 
+* You should see the "Connect to the internet" page.
+  - Use the UI to connect to a network.
+  - Click "Next".
 
-<dt>You should be greeted with a panel where you are prompted to set any of your needed or desired accessibility options.</dt>
-  <dd>Click through the options, (Seeing, Hearing, Typing, Pointing and clicking, Zoom) and make sure the drop down options are fully functional.</dd>
+* You should see the "Try or install Ubuntu" page.
+  - Click "Install Ubuntu".
 
+* You should see the "Type of installation" page.
+  - Select "Interactive installation".
+  - Click "Next".
 
-<dt>You're greeted with the 'Try or install FAMILY' slide. The 'FAMILY' logo should be on the left hand side.</dt>
-  <dd>Select "Install Ubuntu" to continue with the installation process, or "Try Ubuntu" to boot into a live session.</dd>
+* You should see the "Applications" page.
+  - Select "Default selection".
+  - Click "Next".
 
+* You should see the "Optimise your computer" page.
+  - Leave the checkboxes unchecked.
+  - Click "Next".
 
-<dt>You should be greeted with a slide asking you to confirm your keyboard layout.</dt>
-  <dd>Feel free to either select your desired layout, or use the auto-detect feature at the bottom.</dd>
-<dt>Proceed by clicking "Next"</dt>
+* You should see the "Disk setup" page.
+  - Select "Erase disk and install Ubuntu".
+  - Click "Next".
 
+* You should see the "Encryption and file system" page.
+  - Select "No encryption".
+  - Click "Next".
 
-<dt>The 'Connect to a network' screen should now be displayed</dt>
-<dd>The screen should reflect the current status and display the following options (unless you're in a VM):</dd>
-  <dd>
-     <ul>
-     <li>Wired connection</li>
-     <li>Connect to a Wi-Fi network followed by a scrollable list of available APs, displaying an active one colored with a leading checkmark</li>
-     <li>Connect to a hidden Wi-Fi network</li>
-     <li>I don't want to connect to internet for now</li>
-     </ul>
-  </dd>
-<dd>If you ARE installing in a VM, you should check that the VM automatically has internet access. This is usually via a "wired connection".</dd>
-<dd>If you're testing a testcase that requires no internet access, make sure the install medium does not have internet access by configuring it properly in this slide.</dd>
-<dt>Click "Next"</dt>
+* You should see the "Create your account" page.
+  - Fill in the details for your user account.
+  - Click "Next".
 
+* You should see the "Select your timezone" page.
+  - If your system is connected to the internet, verify that the timezone that was auto-detected is accurate.
+  - Click "Next".
 
-<dt>The 'Applications and updates' screen is displayed, listing normal and minimal installation, as well as options for installing updates, third party software and additional media formats.</dt>
-<dd>Select any options pertinent to the testcase - though "Default installation" is normally the desired option.</dd>
-<dt>Click "Next"</dt>
+* You should see the "Ready to install" page.
+  - Check that the summary of the installation options you selected throughout the process is accurate.
+  - Click "Install".
 
+* You should see a slideshow while the installation is taking place.
+  - Wait for the installation to complete.
 
-  <dd>The 'Installation type' screen is displayed</dd>
+* You should see the "Installation complete" page.
+  - Click "Restart Now".
 
+* Allow the machine to reboot.
 
-<dt>Select "Erase disk and install ubuntu"</dt>
-<dt>Click 'Next'</dt>
+* You should see the login screen with the username you created during the installation process.
+  - Log in with the password you set during the installation process.
 
+----
+**If all actions produce the expected results listed, please submit a `passed` result.**
 
-<dt>You should be greeted with the "Set up your account" slide</dt>
-  <dd>Put in your desired user details.</dd>
-
-
-<dt>You should be greeted with the "Select your timezone" slide</dt>
-  <dd>If your system is connected to the internet, verify that the timezone that was auto-detected is accurate</dd>
-  <dd>Note that, if you're on a VPN, the timezone will be affected by this.</dd>
-<dt>Click 'Next'</dt>
-
-
-<dt>You should be greeted by the "Ready to install" slide.</dt>
-<dt>On this slide, the devices to be changed and the partition table is shown to the user.</dt>
-  <dd>Check that the devices listed and the partition table listed is accurate and representative of the install options you set earlier in the process.</dd>
-<dt>Click 'Next'</dt>
-
-
-<dt>Allow the machine to reboot</dt>
-  <dd>The system boots properly and loads into FAMILY showing username selected</dd>
-
-
-</dl>
-<p>If <strong>all</strong> actions produce the expected results described,
-  please <a href="results#add_result">submit</a> a 'passed' result.</p>
-<p>If <strong>any</strong> action fails, or produces an unexpected result,
-  please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include
-  the bug number when you <a href="results#add_result">submit</a> your
-  result.</p>
-
-
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/resolute/testsuites/Ubuntu Desktop/Mandatory/Install (manual partitioning).md
+++ b/resolute/testsuites/Ubuntu Desktop/Mandatory/Install (manual partitioning).md
@@ -1,97 +1,73 @@
+# Install (manual partitioning)
 
-<p><em>Proceed in your native language if you wish. Instructions will remain in English.</em></p>
-<dl>
+* Boot up the image
+  - If you see the GRUB menu, select the "Try or install Ubuntu" option to boot into the live session.
 
+* Wait for the system to boot into the live session. The desktop installer should open automatically and play a welcome sound.
 
-<dt>Boot up the image</dt>
-  <dd>If you see the GRUB boot menu you should see the following:</dd>
-  <dd>
-     <ul>
-     <li>'Try or Install FAMILY'</li>
-     <li>'FAMILY (safe graphics)'</li>
-     <li>'OEM install (for manufacturers)'</li>
-     <li>'Test memory' (only on BIOS systems)</li>
-     </ul>
-  </dd>
+* You should see the "Choose your language" page.
+  - Pick your desired language. (The instructions will remain in English).
+  - Click "Next".
 
+* You should see the "Accessibility" page.
+  - Click through the options, (Seeing, Hearing, Typing, Pointing and clicking, Zoom) and make sure the drop down options are fully functional.
+  - Click "Next".
 
-<dt>Upon reaching the desktop environment, you should be greeted with the "Choose your language" screen.</dt>
-  <dd>Pick your desired language.</dd>
+* You should see the "Keyboard layout" page.
+  - Choose your desired layout.
+  - Click "Next".
 
+* You should see the "Connect to the internet" page.
+  - Use the UI to connect to a network.
+  - Click "Next".
 
-<dt>You should be greeted with a panel where you are prompted to set any of your needed or desired accessibility options.</dt>
-  <dd>Click through the options, (Seeing, Hearing, Typing, Pointing and clicking, Zoom) and make sure the drop down options are fully functional.</dd>
+* You should see the "Try or install Ubuntu" page.
+  - Click "Install Ubuntu".
 
+* You should see the "Type of installation" page.
+  - Select "Interactive installation".
+  - Click "Next".
 
-<dt>You're greeted with the 'Try or install FAMILY' slide. The 'FAMILY' logo should be on the left hand side.</dt>
-  <dd>Select "Install Ubuntu" to continue with the installation process, or "Try Ubuntu" to boot into a live session.</dd>
+* You should see the "Applications" page.
+  - Select "Default selection".
+  - Click "Next".
 
+* You should see the "Optimise your computer" page.
+  - Leave the checkboxes unchecked.
+  - Click "Next".
 
-<dt>You should be greeted with a slide asking you to confirm your keyboard layout.</dt>
-  <dd>Feel free to either select your desired layout, or use the auto-detect feature at the bottom.</dd>
-<dt>Proceed by clicking "Next"</dt>
+* You should see the "Disk setup" page.
+  - Select "Manual installation".
+  - Click "Next".
 
+* You should see the "Manual partitioning" page.
+  - Select the drive you wish to partition and use the Add "+", Change "Change", and Delete "-" buttons to create your desired scheme.
+  - Once you have your required partitioning scheme laid out, click "Next".
 
-<dt>The 'Connect to a network' screen should now be displayed</dt>
-<dd>The screen should reflect the current status and display the following options (unless you're in a VM):</dd>
-  <dd>
-     <ul>
-     <li>Wired connection</li>
-     <li>Connect to a Wi-Fi network followed by a scrollable list of available APs, displaying an active one colored with a leading checkmark</li>
-     <li>Connect to a hidden Wi-Fi network</li>
-     <li>I don't want to connect to internet for now</li>
-     </ul>
-  </dd>
-<dd>If you ARE installing in a VM, you should check that the VM automatically has internet access. This is usually via a "wired connection".</dd>
-<dd>If you're testing a testcase that requires no internet access, make sure the install medium does not have internet access by configuring it properly in this slide.</dd>
-<dt>Click "Next"</dt>
+* You should see the "Create your account" page.
+  - Fill in the details for your user account.
+  - Click "Next".
 
+* You should see the "Select your timezone" page.
+  - If your system is connected to the internet, verify that the timezone that was auto-detected is accurate.
+  - Click "Next".
 
-<dt>The 'Applications and updates' screen is displayed, listing normal and minimal installation, as well as options for installing updates, third party software and additional media formats.</dt>
-<dd>Select any options pertinent to the testcase - though "Default installation" is normally the desired option.</dd>
-<dt>Click "Next"</dt>
+* You should see the "Ready to install" page.
+  - Check that the summary of the installation options you selected throughout the process is accurate.
+  - Click "Install".
 
+* You should see a slideshow while the installation is taking place.
+  - Wait for the installation to complete.
 
-  <dd>The 'Installation type' screen is displayed</dd>
+* You should see the "Installation complete" page.
+  - Click "Restart Now".
 
+* Allow the machine to reboot.
 
+* You should see the login screen with the username you created during the installation process.
+  - Log in with the password you set during the installation process.
 
-<dt>Select 'Manual Partitioning' and click 'Next'</dt>
-  <dd>A screen showing the current hard disks and partition layouts is displayed</dd>
-<dt>Select the drive you wish to partition and use the Add '+', Change 'Change', and Delete '-' buttons to create your desired scheme</dt>
-  <dd>The screen updates showing your desired partitions and mount points</dd>
-<dt>Once you have your required partitioning scheme laid out, click on 'Continue'</dt>
-  <dd>The 'Write changes to disk' screen is displayed, including the details of incoming partitions changes.</dd>
-<dt>Verify that the partitioning details make sense</dt>
-<dt>Click 'Start Installing'</dt>
+----
+**If all actions produce the expected results listed, please submit a `passed` result.**
 
-
-<dt>You should be greeted with the "Set up your account" slide</dt>
-  <dd>Put in your desired user details.</dd>
-
-
-<dt>You should be greeted with the "Select your timezone" slide</dt>
-  <dd>If your system is connected to the internet, verify that the timezone that was auto-detected is accurate</dd>
-  <dd>Note that, if you're on a VPN, the timezone will be affected by this.</dd>
-<dt>Click 'Next'</dt>
-
-
-<dt>You should be greeted by the "Ready to install" slide.</dt>
-<dt>On this slide, the devices to be changed and the partition table is shown to the user.</dt>
-  <dd>Check that the devices listed and the partition table listed is accurate and representative of the install options you set earlier in the process.</dd>
-<dt>Click 'Next'</dt>
-
-
-<dt>Allow the machine to reboot</dt>
-  <dd>The system boots properly and loads into FAMILY showing username selected</dd>
-
-
-</dl>
-<p>If <strong>all</strong> actions produce the expected results described,
-  please <a href="results#add_result">submit</a> a 'passed' result.</p>
-<p>If <strong>any</strong> action fails, or produces an unexpected result,
-  please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include
-  the bug number when you <a href="results#add_result">submit</a> your
-  result.</p>
-
-
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/resolute/testsuites/Ubuntu Desktop/Mandatory/Install UEFI SecureBoot nVidia.md
+++ b/resolute/testsuites/Ubuntu Desktop/Mandatory/Install UEFI SecureBoot nVidia.md
@@ -1,126 +1,105 @@
+# Install (UEFI Secure Boot with nVidia)
 
-    <p><em>Proceed in your native language if you wish. Instructions will remain in English.</em></p>
-    <dl>
+This test is to ensure that the image boots in UEFI, that the resulting installation can boot in UEFI as well, regardless of network availability and that nVidia proprietary drivers are installed and loaded.
+Boot up the image in UEFI mode with Secure Boot enabled.
 
-    <dd><p>This test is to ensure that the image boots in UEFI, that the</dd>
-       <dd>resulting installation can boot in UEFI as well, regardless of network</dd>
-       <dd>availability and that nVidia proprietary drivers are installed and loaded.</dd>
-    <dt>Boot up the image in UEFI mode with <b>Secure Boot enabled</b></dt>
+* Boot up the image
+  - If you see the GRUB menu, select the "Try or install Ubuntu" option to boot into the live session.
 
-    <dt>Boot up the image</dt>
-      <dd>If you see the GRUB boot menu you should see the following:</dd>
-      <dd>
-         <ul>
-         <li>'Try or Install FAMILY'</li>
-         <li>'FAMILY (safe graphics)'</li>
-         <li>'OEM install (for manufacturers)'</li>
-         <li>'Test memory' (only on BIOS systems)</li>
-         </ul>
-      </dd>
+* Wait for the system to boot into the live session. The desktop installer should open automatically and play a welcome sound.
 
+* You should see the "Choose your language" page.
+  - Pick your desired language. (The instructions will remain in English).
+  - Click "Next".
 
-    <dt>Upon reaching the desktop environment, you should be greeted with the "Choose your language" screen.</dt>
-      <dd>Pick your desired language.</dd>
+* You should see the "Accessibility" page.
+  - Click through the options, (Seeing, Hearing, Typing, Pointing and clicking, Zoom) and make sure the drop down options are fully functional.
+  - Click "Next".
 
+* You should see the "Keyboard layout" page.
+  - Choose your desired layout.
+  - Click "Next".
 
-    <dt>You should be greeted with a panel where you are prompted to set any of your needed or desired accessibility options.</dt>
-      <dd>Click through the options, (Seeing, Hearing, Typing, Pointing and clicking, Zoom) and make sure the drop down options are fully functional.</dd>
+* You should see the "Connect to the internet" page.
+  - Use the UI to connect to a network.
+  - Click "Next".
 
+* You should see the "Try or install Ubuntu" page.
+  - Click "Install Ubuntu".
 
-    <dt>You're greeted with the 'Try or install FAMILY' slide. The 'FAMILY' logo should be on the left hand side.</dt>
-      <dd>Select "Install Ubuntu" to continue with the installation process, or "Try Ubuntu" to boot into a live session.</dd>
+* You should see the "Type of installation" page.
+  - Select "Interactive installation".
+  - Click "Next".
 
+* You should see the "Applications" page.
+  - Select "Default selection".
+  - Click "Next".
 
-    <dt>You should be greeted with a slide asking you to confirm your keyboard layout.</dt>
-      <dd>Feel free to either select your desired layout, or use the auto-detect feature at the bottom.</dd>
-    <dt>Proceed by clicking "Next"</dt>
+* You should see the "Optimise your computer" page.
+  - Check the "Install third-party software for graphics and Wi-Fi hardware and additional media formats" option.
+  - Click "Next".
 
-    <dt>In the next slide, disconnect from any network using the top panel controls.</dt>
+* You should see the "Disk setup" page.
+  - Select "Erase disk and install Ubuntu".
+  - Click "Next".
 
-    <dt>The 'Connect to a network' screen should now be displayed</dt>
-    <dd>The screen should reflect the current status and display the following options (unless you're in a VM):</dd>
-      <dd>
-         <ul>
-         <li>Wired connection</li>
-         <li>Connect to a Wi-Fi network followed by a scrollable list of available APs, displaying an active one colored with a leading checkmark</li>
-         <li>Connect to a hidden Wi-Fi network</li>
-         <li>I don't want to connect to internet for now</li>
-         </ul>
-      </dd>
-    <dd>If you ARE installing in a VM, you should check that the VM automatically has internet access. This is usually via a "wired connection".</dd>
-    <dd>If you're testing a testcase that requires no internet access, make sure the install medium does not have internet access by configuring it properly in this slide.</dd>
-    <dt>Click "Next"</dt>
+* You should see the "Encryption and file system" page.
+  - Select "No encryption".
+  - Click "Next".
 
-    <dt>In the next slide, check 'Install third-party software for graphics and Wi-Fi hardware'</dt>
+* You should see the "Create your account" page.
+  - Fill in the details for your user account.
+  - Click "Next".
 
-    <dt>The 'Applications and updates' screen is displayed, listing normal and minimal installation, as well as options for installing updates, third party software and additional media formats.</dt>
-    <dd>Select any options pertinent to the testcase - though "Default installation" is normally the desired option.</dd>
-    <dt>Click "Next"</dt>
+* You should see the "Select your timezone" page.
+  - If your system is connected to the internet, verify that the timezone that was auto-detected is accurate.
+  - Click "Next".
 
+* You should see the "Ready to install" page.
+  - Check that the summary of the installation options you selected throughout the process is accurate.
+  - Click "Install".
 
-      <dd>The 'Installation type' screen is displayed</dd>
+* You should see a slideshow while the installation is taking place.
+  - Wait for the installation to complete.
 
+* You should see the "Installation complete" page.
+  - Click "Restart Now".
 
-    <dt>Select "Erase disk and install ubuntu"</dt>
-    <dt>Click 'Next'</dt>
+* Allow the machine to reboot.
 
+* You should see the login screen with the username you created during the installation process.
+  - Log in with the password you set during the installation process.
 
-    <dt>You should be greeted with the "Set up your account" slide</dt>
-      <dd>Put in your desired user details.</dd>
+* Open a terminal, run the following commands and verify their output (the exact output depends on your hardware):
+  - `nvidia-smi`
+    ```
+    Thu Apr 23 11:40:22 2020       
+    +-----------------------------------------------------------------------------+
+    | NVIDIA-SMI 440.64       Driver Version: 440.64       CUDA Version: 10.2     |
+    |-------------------------------+----------------------+----------------------+
+    | GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
+    | Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
+    |===============================+======================+======================|
+    |   0  GeForce MX150       Off  | 00000000:01:00.0 Off |                  N/A |
+    | N/A   48C    P0    N/A /  N/A |      0MiB /  2002MiB |      0%      Default |
+    +-------------------------------+----------------------+----------------------+
 
+    +-----------------------------------------------------------------------------+
+    | Processes:                                                       GPU Memory |
+    |  GPU       PID   Type   Process name                             Usage      |
+    |=============================================================================|
+    |  No running processes found                                                 |
+    +-----------------------------------------------------------------------------+
+    ```
+  - `sudo prime-supported`
+    ```
+    yes
+    ```
+  - `nvidia-settings`
 
-    <dt>You should be greeted with the "Select your timezone" slide</dt>
-      <dd>If your system is connected to the internet, verify that the timezone that was auto-detected is accurate</dd>
-      <dd>Note that, if you're on a VPN, the timezone will be affected by this.</dd>
-    <dt>Click 'Next'</dt>
+    Verify that settings are displayed and you can configure the card.
+    
+----
+**If all actions produce the expected results listed, please submit a `passed` result.**
 
-
-    <dt>You should be greeted by the "Ready to install" slide.</dt>
-    <dt>On this slide, the devices to be changed and the partition table is shown to the user.</dt>
-      <dd>Check that the devices listed and the partition table listed is accurate and representative of the install options you set earlier in the process.</dd>
-    <dt>Click 'Next'</dt>
-
-
-    <dt>Allow the machine to reboot</dt>
-      <dd>The system boots properly and loads into FAMILY showing username selected</dd>
-
-    <dt>Allow the machine to reboot</dt>
-        <dd>The system boots properly and loads into FAMILY showing username selected</dd>
-    <dt>Login</dt>
-        <dd>The session starts</dd>
-    <dt>Open a terminal, run the following commands and verify their output (the output depends on your hardware)</dt>
-        <dd><code>
-$ nvidia-smi
-Thu Apr 23 11:40:22 2020       
-+-----------------------------------------------------------------------------+
-| NVIDIA-SMI 440.64       Driver Version: 440.64       CUDA Version: 10.2     |
-|-------------------------------+----------------------+----------------------+
-| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
-| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
-|===============================+======================+======================|
-|   0  GeForce MX150       Off  | 00000000:01:00.0 Off |                  N/A |
-| N/A   48C    P0    N/A /  N/A |      0MiB /  2002MiB |      0%      Default |
-+-------------------------------+----------------------+----------------------+
-
-+-----------------------------------------------------------------------------+
-| Processes:                                                       GPU Memory |
-|  GPU       PID   Type   Process name                             Usage      |
-|=============================================================================|
-|  No running processes found                                                 |
-+-----------------------------------------------------------------------------+
-
-$ sudo prime-supported
-yes
-        </code></dd>
-    <dt>Run 'nvidia-settings'</dt>
-        <dd>Verify that settings are displayed and you can configure the card</dd>
-
-    </dl>
-    <p>If <strong>all</strong> actions produce the expected results described,
-      please <a href="results#add_result">submit</a> a 'passed' result.</p>
-    <p>If <strong>any</strong> action fails, or produces an unexpected result,
-      please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include
-      the bug number when you <a href="results#add_result">submit</a> your
-      result.</p>
-
-
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/resolute/testsuites/Ubuntu Desktop/Mandatory/Install no TPM option without TPM support.md
+++ b/resolute/testsuites/Ubuntu Desktop/Mandatory/Install no TPM option without TPM support.md
@@ -1,71 +1,54 @@
+# Install (entire disk with TPM encryption)
 
-<p><em>Proceed in your native language if you wish. Instructions will remain in English.</em></p>
-<dl>
+For this check, please use a system with no TPM enabled hardware.
 
-<dt>In this test case, make sure that the machine you're installing on does not have the HW requirements for TPM FDE.</dt>
+* Boot up the image
+  - If you see the GRUB menu, select the "Try or install Ubuntu" option to boot into the live session.
 
-<dt>Boot up the image</dt>
-  <dd>If you see the GRUB boot menu you should see the following:</dd>
-  <dd>
-     <ul>
-     <li>'Try or Install FAMILY'</li>
-     <li>'FAMILY (safe graphics)'</li>
-     <li>'OEM install (for manufacturers)'</li>
-     <li>'Test memory' (only on BIOS systems)</li>
-     </ul>
-  </dd>
+* Wait for the system to boot into the live session. The desktop installer should open automatically and play a welcome sound.
 
+* You should see the "Choose your language" page.
+  - Pick your desired language. (The instructions will remain in English).
+  - Click "Next".
 
-<dt>Upon reaching the desktop environment, you should be greeted with the "Choose your language" screen.</dt>
-  <dd>Pick your desired language.</dd>
+* You should see the "Accessibility" page.
+  - Click through the options, (Seeing, Hearing, Typing, Pointing and clicking, Zoom) and make sure the drop down options are fully functional.
+  - Click "Next".
 
+* You should see the "Keyboard layout" page.
+  - Choose your desired layout.
+  - Click "Next".
 
-<dt>You should be greeted with a panel where you are prompted to set any of your needed or desired accessibility options.</dt>
-  <dd>Click through the options, (Seeing, Hearing, Typing, Pointing and clicking, Zoom) and make sure the drop down options are fully functional.</dd>
+* You should see the "Connect to the internet" page.
+  - Use the UI to connect to a network.
+  - Click "Next".
 
+* You should see the "Try or install Ubuntu" page.
+  - Click "Install Ubuntu".
 
-<dt>You're greeted with the 'Try or install FAMILY' slide. The 'FAMILY' logo should be on the left hand side.</dt>
-  <dd>Select "Install Ubuntu" to continue with the installation process, or "Try Ubuntu" to boot into a live session.</dd>
+* You should see the "Type of installation" page.
+  - Select "Interactive installation".
+  - Click "Next".
 
+* You should see the "Applications" page.
+  - Select "Default selection".
+  - Click "Next".
 
-<dt>You should be greeted with a slide asking you to confirm your keyboard layout.</dt>
-  <dd>Feel free to either select your desired layout, or use the auto-detect feature at the bottom.</dd>
-<dt>Proceed by clicking "Next"</dt>
+* You should see the "Optimise your computer" page.
+  - Leave the checkboxes unchecked.
+  - Click "Next".
 
+* You should see the "Disk setup" page.
+  - Select "Erase disk and install Ubuntu".
+  - Click "Next".
 
-<dt>The 'Connect to a network' screen should now be displayed</dt>
-<dd>The screen should reflect the current status and display the following options (unless you're in a VM):</dd>
-  <dd>
-     <ul>
-     <li>Wired connection</li>
-     <li>Connect to a Wi-Fi network followed by a scrollable list of available APs, displaying an active one colored with a leading checkmark</li>
-     <li>Connect to a hidden Wi-Fi network</li>
-     <li>I don't want to connect to internet for now</li>
-     </ul>
-  </dd>
-<dd>If you ARE installing in a VM, you should check that the VM automatically has internet access. This is usually via a "wired connection".</dd>
-<dd>If you're testing a testcase that requires no internet access, make sure the install medium does not have internet access by configuring it properly in this slide.</dd>
-<dt>Click "Next"</dt>
+* You should see the "Encryption and file system" page.
+  - Select "Use hardware-backed encryption".
+  - Click "Next".
 
+* You should see an error page with the message "Hardware-backed encryption could not be enabled".
 
-<dt>The 'Applications and updates' screen is displayed, listing normal and minimal installation, as well as options for installing updates, third party software and additional media formats.</dt>
-<dd>Select any options pertinent to the testcase - though "Default installation" is normally the desired option.</dd>
-<dt>Click "Next"</dt>
+----
+**If all actions produce the expected results listed, please submit a `passed` result.**
 
-
-  <dd>The 'Installation type' screen is displayed</dd>
-
-
-<dt>For this check, please use a system with no TPM enabled hardware</dt>
-
-<dt>That's it. If the checkbox isn't available, this testcase has passed.</dt>
-
-</dl>
-<p>If <strong>all</strong> actions produce the expected results described,
-  please <a href="results#add_result">submit</a> a 'passed' result.</p>
-<p>If <strong>any</strong> action fails, or produces an unexpected result,
-  please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include
-  the bug number when you <a href="results#add_result">submit</a> your
-  result.</p>
-
-
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/resolute/testsuites/Ubuntu Desktop/Mandatory/Live Session.md
+++ b/resolute/testsuites/Ubuntu Desktop/Mandatory/Live Session.md
@@ -1,24 +1,34 @@
-<em>Proceed in your native language if you wish. Instructions will remain in English</em>
+# Install (entire disk)
 
-Test-case Live Session Start
-<dl>
-    <dt>Boot up the image</dt>
-        <dd>FAMILY boot screen is displayed</dd>
-    <dt>When the installer starts select your language in the left column</dt>
-        <dd>Language is selected, all labels are changed to translated versions</dd>
-    <dt>Click Continue</dt>
-        <dd>The 'Try or Install' screen is displayed with 'try FAMILY' and 'Install FAMILY' buttons</dd>
-    <dt>Click on the 'Try FAMILY' icon to select the option and click on the 'Continue' button</dt>
-        <dd>The default desktop is displayed</dd>
-</dl>
-Test-case Live Session Usage
-<dl>
-    <dt>Use and execute the default applications found for the desktop enviroment being run</dt>
-        <dd>All applications should function without error</dd>
-</dl>
+* Boot up the image
+  - If you see the GRUB menu, select the "Try or install Ubuntu" option to boot into the live session.
 
-<strong>
-    If all actions produce the expected results listed, please <a href="results#add_result">submit</a> a 'passed' result.
-    If an action fails, or produces an unexpected result, please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include the bug number when you <a href="results#add_result">submit</a> your result.</strong>
+* Wait for the system to boot into the live session. The desktop installer should open automatically and play a welcome sound.
+
+* You should see the "Choose your language" page.
+  - Pick your desired language. (The instructions will remain in English).
+  - Click "Next".
+
+* You should see the "Accessibility" page.
+  - Click through the options, (Seeing, Hearing, Typing, Pointing and clicking, Zoom) and make sure the drop down options are fully functional.
+  - Click "Next".
+
+* You should see the "Keyboard layout" page.
+  - Choose your desired layout.
+  - Click "Next".
+
+* You should see the "Connect to the internet" page.
+  - Use the UI to connect to a network.
+  - Click "Next".
+
+* You should see the "Try or install Ubuntu" page.
+  - Click "Try Ubuntu".
+
+* Use and execute the default applications found for the desktop enviroment being run.
+  - All applications should function without error.
 
 
+----
+**If all actions produce the expected results listed, please submit a `passed` result.**
+
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**


### PR DESCRIPTION
I've updated the existing `Mandatory` tests for `Ubuntu Desktop` by converting the HTML dump to markdown and adapting the instructions to follow the current UX flow of the desktop installer.

Ref: #18 

UDENG-9456