### PR TITLE
Fix the "install no tpm without TPM support" test

### DIFF
--- a/resolute/testsuites/Ubuntu Desktop/Mandatory/Install no TPM option without TPM support.md
+++ b/resolute/testsuites/Ubuntu Desktop/Mandatory/Install no TPM option without TPM support.md
@@ -24,10 +24,6 @@
   <dd>Click through the options, (Seeing, Hearing, Typing, Pointing and clicking, Zoom) and make sure the drop down options are fully functional.</dd>
 
 
-<dt>You're greeted with the 'Try or install FAMILY' slide. The 'FAMILY' logo should be on the left hand side.</dt>
-  <dd>Select "Install Ubuntu" to continue with the installation process, or "Try Ubuntu" to boot into a live session.</dd>
-
-
 <dt>You should be greeted with a slide asking you to confirm your keyboard layout.</dt>
   <dd>Feel free to either select your desired layout, or use the auto-detect feature at the bottom.</dd>
 <dt>Proceed by clicking "Next"</dt>
@@ -47,18 +43,26 @@
 <dd>If you're testing a testcase that requires no internet access, make sure the install medium does not have internet access by configuring it properly in this slide.</dd>
 <dt>Click "Next"</dt>
 
+<dt>The 'Update available' screen MAY be displayed</dt>
+<dd>If there is an update for the installer, a screen allowing to update it will appear. Click on the "Update now" button, exit the installer, launch it again from the dock (or from the "Install Ubuntu 26.04" icon on the desktop), and repeat the previous steps.</dd>
 
-<dt>The 'Applications and updates' screen is displayed, listing normal and minimal installation, as well as options for installing updates, third party software and additional media formats.</dt>
-<dd>Select any options pertinent to the testcase - though "Default installation" is normally the desired option.</dd>
+
+<dt>You're greeted with the 'Install type' slide, with three options: "Interactive install", "Automatic with an autoinstall file", and "Automatic with Landscape".</dt>
+  <dd>Select "Interactive install" to continue with the installation process.</dd>
+
+<dt>Now you are greeted with the 'Applications' slide, listing normal and enhanced installation options</dt>
+<dd>Choose "Predetermined selection" to continue.</dd>
+
+<dt>The 'Optimize your device' screen is displayed, where you can choose wheter to install or not other drivers, like the nVidia ones or certain privative Wi-Fi drivers. Also allows to install third-party multimedia formats.</dt>
+<dd>Select any options pertinent to the testcase.</dd>
 <dt>Click "Next"</dt>
 
+<dt>The 'Disk configuration' page will be displayed. Here you can choose whether to delete the entire disk, or manually partition it</dt>
+<dd>Select any options pertinent to the testcase.</dd>
 
-  <dd>The 'Installation type' screen is displayed</dd>
+  <dd>The 'Encryption and file system' screen is displayed</dd>
 
-
-<dt>For this check, please use a system with no TPM enabled hardware</dt>
-
-<dt>That's it. If the checkbox isn't available, this testcase has passed.</dt>
+<dt>For this check, please use a system with no TPM enabled hardware. Try choosing "Use hardware-backed encryption". The installer should show a new page notifying that it wasn't possible to enable it, and only allowing to go back. Now choose "No encryption" and ensure that the system is installed correctly.</dt>
 
 </dl>
 <p>If <strong>all</strong> actions produce the expected results described,


### PR DESCRIPTION
The "install no tpm without TPM support" entry doesn't match the current installer steps: not only the pages are different and have different order, but also the TPM option is always visible, and just shows an error page if chosen in a non-TPM machine.