### PR TITLE
ubuntucinnamon: Add install cinnamon spices test

### DIFF
--- a/stonking/testsuites/Ubuntu Cinnamon Desktop/Run-Once/Install Cinnamon Spices.md
+++ b/stonking/testsuites/Ubuntu Cinnamon Desktop/Run-Once/Install Cinnamon Spices.md
@@ -1,0 +1,64 @@
+# Install Cinnamon Spices
+
+This test ensures that the user is able to download the different Cinnamon spices: applets (which appear in the panel), desklets (which appear on the desktop), themes (for Cinnamon and/or GTK), extensions (miscellaneous/general to Cinnamon), and actions (for the file manager, Nemo).
+
+Keep in mind that spices are not officially maintained. Bugs should not be filed because of bugs in one particular spice; bugs should be filed if there is a bug in Cinnamon itself preventing many spices from working or being installable.
+
+Some spices may also have other dependencies. Make sure you install them if you choose to use that specific spice.
+
+* Download an Applet
+  - Open the "Applets" settings through the application menu, or by clicking the icon in the settings menu
+  - Click the "Download" menu button at the top
+  - The listing of available applets is shown (you may need to wait for it to download)
+  - Click the download icon next to any applet of your choosing
+  - Click the "Manage" menu button at the top
+  - Select the applet you chose to download, and then click on the plus (+) icon in the bottom row to add it to the panel.
+  - You should now be able to see the installed applet in your panel.
+  - If you wish, click on the minus (-) icon in the bottom row to remove the applet from the panel. Alternatively, you can right click on the applet in the panel, and select the "Remove" button that appears.
+
+* Download a Desklet
+  - Open the "Desklets" settings through the application menu, or by clicking the icon in the settings menu
+  - Click the "Download" menu button at the top
+  - The listing of available desklets is shown (you may need to wait for it to download)
+  - Click the download icon next to any desklets of your choosing
+  - Click the "Manage" menu button at the top
+  - Select the desklet you chose to download, and then click on the plus (+) icon in the bottom row to add it to the desktop.
+  - You should now be able to see the installed desklet on your desktop. It can be dragged around by holding left click and moving the mouse.
+  - If you wish, click on the minus (-) icon in the bottom row to remove the desklet from the desktop. Alternatively, you can right click on the desklet, and select the "Remove" button that appears.
+
+* Download an Extension
+  - Open the "Extensions" settings through the application menu, or by clicking the icon in the settings menu
+  - Click the "Download" menu button at the top
+  - The listing of available extensions is shown (you may need to wait for it to download)
+  - Click the download icon next to any extension of your choosing
+  - Click the "Manage" menu button at the top
+  - Select the extension you chose to download, and then click on the plus (+) icon in the bottom row to enable it.
+  - You should now be able to see the effects of the extension being enabled.
+  - If you wish, click on the minus (-) icon in the bottom row to disable the extension.
+
+* Download a Theme
+  - Open the "Themes" settings through the application menu, or by clicking the icon in the settings menu
+  - Click the "Add/Remove" menu button at the top
+  - The listing of available themes is shown (you may need to wait for it to download)
+  - Click the download icon next to any theme of your choosing
+  - Click the "Themes" menu button at the top
+  - Select the theme you chose to download by selecting the theme type (most likely in the "Applications", "Icons", and/or "Desktop") box, and selecting the theme name in the menu that appears.
+  - You should now be able to see the theme applied.
+  - If you wish, you can click on the theme box to choose a different theme, or to remove the theme, switch to the "Add/Remove" menu, select the theme installed, and click on the minus (-) icon in the bottom row to uninstall the theme.
+
+* Download an Action
+  - Open the "Actions" settings through the application menu, or by clicking the icon in the settings menu
+  - Click the "Download" menu button at the top
+  - The listing of available actions is shown (you may need to wait for it to download)
+  - Click the download icon next to any action of your choosing.
+  - Click the "Manage" menu button at the top
+  - Select the action you chose to download, and then click on the plus (+) icon in the bottom row to enable it.
+  - Open the file manager (nemo, the "Files" app)
+  - Right click on an item or directory where the appropriately installed action should appear as an operation (which item specifically depends on the action you installed)
+  - You should now be able to run the action.
+  - If you wish, go back to the "Actions" settings menu, and under the "Manage" tab, click on the minus (-) icon in the bottom row to disable the action.
+
+----
+**If all actions produce the expected results listed, please submit a `passed` result.**
+
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**


### PR DESCRIPTION
A bug was found that prevents all Cinnamon spices from being downloadable. A simple run once test to ensure that this functionality works would be helpful to prevent this in future releases.

https://bugs.launchpad.net/ubuntu/+source/cinnamon/+bug/2152641