### PR TITLE
fix(wsl): Format and content updates

### DIFF
--- a/noble/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/noble/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -15,34 +15,14 @@ host (Windows) filesystem (if they exist):
 - `%USERPROFILE%\.cloud-init`
 - `%USERPROFILE%\.ubuntupro\cloud-init`
 
-After downloading the image, navigate to it on Windows explorer:
+**Double click to install:**
 
-**Double-click the image to start the installation**
+After downloading the image, navigate to it on Windows explorer and double-click the image file to start the installation.
 
 A new terminal window will pop-up showing the registration progress. In the end it will
-give instructions to start a new shell into the new instance. Take note of that command. For
-example (for noble):
-
-```
-> wsl.exe -d Ubuntu-24.04
-```
-
-Verify that the new instance has been registered by running the following command:
-
-```
-> wsl.exe --list --all --verbose
-NAME             STATE           VERSION
-*Ubuntu          Running         2
-Ubuntu-24.04     Stopped         2
-Ubuntu-20.04     Stopped         2
-TestUbuntuWSL    Stopped         2
-```
-
-Check the the name used in previous command appears in the list.
-
-**Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
-the new user creation. The input line should be prefilled with a user name derived from the
-current Windows user name.**
+run the first boot experience, the provisioning (OOBE) command, and eventually will prompt for
+the new user creation. **The input line should be prefilled with a user name derived from the
+current Windows user name**, but that's a suggestion, users are free to change it and hit enter.
 
 In the example below the Windows user name is ubuntu:
 

--- a/noble/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/noble/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -225,5 +225,8 @@ Ubuntu-20.04
 TestUbuntuWSL
 ```
 
-**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
-If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**
+---- 
+
+**If all actions produce the expected results listed, please submit a `passed` result.** 
+
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/noble/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/noble/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -1,6 +1,6 @@
 This case tests the implicit provisioning (double-click install) of a tar-based WSL image.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.5.7 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/noble/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/noble/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -119,10 +119,43 @@ Verify that the command ends successfully and that any package that must be upgr
 $ sudo apt install hello
 ```
 
-Verify that the package has been successfully installed and the application can run:
+Verify that the package has been successfully installed and the application can run
+(If `/snap/bin` is not automatically added to your `PATH` then run `source /etc/profile`): 
 
 ```
 $ hello
+Hello, world!
+```
+
+**Install a snap package**
+
+```
+$ sudo apt remove hello
+```
+
+Verify that the package has been successfully uninstalled and the application can run:
+
+```
+$ hello
+Command 'hello' not found, but can be installed with:
+sudo snap install hello  # version 2.10, or
+sudo apt  install hello  # version 2.10-5build1
+See 'snap info hello' for additional versions.
+```
+
+Then install the snap version:
+
+```
+$ sudo snap install hello
+```
+
+Verify that the package has been successfully installed and the application can run
+(If `/snap/bin` is not automatically added to your `PATH` then run `source /etc/profile`): 
+
+```
+$ hello
+Hello, world!
+$ snap run hello
 Hello, world!
 ```
 
@@ -160,6 +193,22 @@ It's possible that it fails due [this WSL bug](https://github.com/microsoft/WSL/
 $ GDK_BACKEND=wayland XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir gtk4-demo
 (Wait a moment until the application starts and is displayed)
 ```
+
+Try a graphical snap as well:
+
+```
+sudo snap install gnome-system-monitor
+gnome-system-monitor
+gnome-system-monitor
+libpxbackend-1.0.so: cannot open shared object file: No such file or directory
+Failed to load module: /home/user/snap/gnome-system-monitor/common/.cache/gio-modules/libgiolibproxy.so
+
+(gnome-system-monitor:6963): Gtk-WARNING **: 16:02:47.323: Trying to measure GtkButton 0x5757299c71e0 for width of 80, but it needs at least 88
+
+(gnome-system-monitor:6963): Gtk-CRITICAL **: 16:02:47.324: Allocation width too small. Tried to allocate 80x31, but GtkButton 0x5757299c71e0 needs at least 88x31.
+```
+
+_Some warnings may show up, the exact ones may depend on the application and version, but the window should render correctly and be functional_.
 
 **Check that Windows interoperability is still working**
 

--- a/noble/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/noble/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -166,7 +166,7 @@ $ sudo apt install x11-apps gtk-4-examples libgles2
 [...]
 ```
 
-Start one of the graphical application from the x11-apps package, like xcalc for example:
+Start one of the graphical applications from the x11-apps package, like xcalc for example:
 
 ```
 $ xcalc

--- a/noble/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/noble/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -1,6 +1,6 @@
 This case tests the implicit provisioning (double-click install) of a tar-based WSL image.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/noble/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/noble/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -187,9 +187,11 @@ dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 logout
 ```
 
-Check that your back to the PowerShell prompt.
+The terminal window will close.
 
 **Unregister the distro instance**
+
+Run the following command on a new PowerShell tab:
 
 ```
 > wsl.exe --unregister Ubuntu-24.04

--- a/noble/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/noble/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -1,58 +1,62 @@
-<p>This case tests the implicit provisioning (double-click install) of a tar-based WSL image.</p>
+This case tests the implicit provisioning (double-click install) of a tar-based WSL image.
 
 It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
 
-Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at <a href="https://cdimages.ubuntu.com/ubuntu-wsl/">https://cdimages.ubuntu.com/ubuntu-wsl/</a>
+Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".
 
-For example for latest noble image:  <a href="https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl">https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/noble/pending/noble-wsl-amd64.wsl</a>
+For example for latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
 Make sure to download the image matching the correct release under test from the download link associated to this test case.
 
 Those images have cloud-init seeded. To make sure your environment doesn't contain any files that could
 cause cloud-init to change the expected results of this test cases, remove the following directories on the
 host (Windows) filesystem (if they exist):
 
-<ul>
-	<li>%USERPROFILE%\.cloud-init</li>
-	<li>%USERPROFILE%\.ubuntupro\cloud-init</li>
-</ul>
+- `%USERPROFILE%\.cloud-init`
+- `%USERPROFILE%\.ubuntupro\cloud-init`
 
 After downloading the image, navigate to it on Windows explorer:
 
-<dl>
-	<dt>Double-click the image to start the installation</dt>
-		<dd>A new terminal window will pop-up showing the registration progress. In the end it will
-		give instructions to start a new shell into the new instance. Take note of that command. For
-		example (for noble):
-<pre>
+**Double-click the image to start the installation**
+
+A new terminal window will pop-up showing the registration progress. In the end it will
+give instructions to start a new shell into the new instance. Take note of that command. For
+example (for noble):
+
+```
 > wsl.exe -d Ubuntu-24.04
-</pre>
-		</dd>
-		<dd>Verify that the new instance has been registered by running the following command:
-<pre>
+```
+
+Verify that the new instance has been registered by running the following command:
+
+```
 > wsl.exe --list --all --verbose
 NAME             STATE           VERSION
 *Ubuntu          Running         2
 Ubuntu-24.04     Stopped         2
 Ubuntu-20.04     Stopped         2
 TestUbuntuWSL    Stopped         2
-</pre>
-		</dd>
-		<dd>Check the the name used in previous command appears in the list.</dd>
+```
 
-	<dt>Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
-		the new user creation. The input line should be prefilled with a user name derived from the
-		current Windows user name.</dt>
-		<dd>In the example below the Windows user name is ubuntu
-<pre>
+Check the the name used in previous command appears in the list.
+
+**Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
+the new user creation. The input line should be prefilled with a user name derived from the
+current Windows user name.**
+
+In the example below the Windows user name is ubuntu:
+
+```
 > wsl -d Ubuntu-24.04
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
-</pre></dd>
-	<dd>Hit enter and proceed with the default user creation. Once done you should be running bash inside
-	the distro instance
-<pre>
+```
+
+Hit enter and proceed with the default user creation. Once done you should be running bash inside
+the distro instance:
+
+```
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
@@ -78,91 +82,116 @@ Welcome to Ubuntu 24.04.2 LTS (GNU/Linux 5.15.167.4-microsoft-standard-WSL2 x86_
 This message is shown once a day. To disable it please create the
 /home/ubuntu/.hushlogin file.
 ubuntu@mib01:/mnt/c/Users/ubuntu$
-</pre></dd>
+```
 
-		<dd>Verify that	you're running the right distribution (point) release. For example run:
-<pre>
+Verify that you're running the right distribution (point) release. For example run:
+
+```
 $ lsb_release -a
 No LSB modules are available.
 Distributor ID: Ubuntu
 Description:    Ubuntu 24.04.2 LTS
 Release:        24.04
 Codename:       noble
-</pre> </dd>
+```
 
-	<dt>Check systemd status</dt>
-		<dd>Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
-<pre>
+**Check systemd status**
+
+Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
+
+```
 $ systemctl is-system-running
 running
 $ systemctl --failed
   UNIT LOAD ACTIVE SUB DESCRIPTION
 
   0 loaded units listed.
-</pre></dd>
+```
 
-	<dt>The default user</dt>
-		<dd>You should be logged in with the user that you just created
-<pre>
+**The default user**
+
+You should be logged in with the user that you just created:
+
+```
 $ whoami
 ubuntu
-</pre></dd>
-		<dd>Run a command as root with sudo, for instance
-<pre>$ sudo apt update</pre></dd>
-		<dd>Verify that the command ends successfully</dd>
-		<dd>Apply any update
-<pre>$ sudo apt full-upgrade</pre></dd>
-		<dd>Verify that the command ends successfully and that any packge that must be upgraded has been upgraded</dd>
-		<dd>Install a package
-<pre>$ sudo apt install hello</pre></dd>
-		<dd>Verify that the package has been successfully installed and the application can run
-<pre>
+```
+
+Run a command as root with sudo, for instance:
+
+```
+$ sudo apt update
+```
+
+Verify that the command ends successfully.
+
+Apply any update:
+
+```
+$ sudo apt full-upgrade
+```
+
+Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
+
+Install a package:
+
+```
+$ sudo apt install hello
+```
+
+Verify that the package has been successfully installed and the application can run:
+
+```
 $ hello
 Hello, world!
-</pre></dd>
+```
 
-	<dt>Install and run graphical applications
-	    </dt>
-	    <dd>
-<pre>
+**Install and run graphical applications**
+
+```
 $ sudo apt install x11-apps gtk-4-examples libgles2
 [...]
-</pre>
-	    </dd>
-		<dd>Start one of the graphical application from the x11-apps package, like xcalc for example:
-<pre>
+```
+
+Start one of the graphical application from the x11-apps package, like xcalc for example:
+
+```
 $ xcalc
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the default backend:
-<pre>
+Start the GTK demo application with the default backend:
+
+```
 $ gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the Wayland backend:
-<pre>
+Start the GTK demo application with the Wayland backend:
+
+```
 $ GDK_BACKEND=wayland gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre>
-		It's possible that it fails due <a href="https://github.com/microsoft/WSL/issues/11261">this
-			WSL bug</a>. To confirm that try again with a different XDG_RUNTIME_DIR as below:
-<pre>
+```
+
+It's possible that it fails due [this WSL bug](https://github.com/microsoft/WSL/issues/11261). To confirm that try again with a different XDG_RUNTIME_DIR as below:
+
+```
 $ GDK_BACKEND=wayland XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre>
-		</dd>
+```
 
-	<dt>Check that Windows interoperability is still working
-	</dt>
-		<dd> Launch a Windows application
-<pre>
+**Check that Windows interoperability is still working**
+
+Launch a Windows application:
+
+```
 > notepad.exe # It should open.
-</pre>
-		</dd>
-		<dd> List the contents of the C:\Windows
-<pre>
+```
+
+List the contents of the `C:\Windows`:
+
+```
 > ls -l /mnt/c/Windows
 dr-xr-xr-x 1 root root     512 Feb 11 08:58  AppReadiness
 dr-xr-xr-x 1 root root     512 Apr  1  2024  Boot
@@ -170,37 +199,31 @@ dr-xr-xr-x 1 root root     512 Apr  1  2024  Branding
 dr-xr-xr-x 1 root root     512 Oct  7 14:37  BrowserCore
 dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 [...]
-</pre>
-		</dd>
+```
 
-	<dt>Exit WSL
-	    </dt>
-	    <dd>
-<pre>logout</pre>
-	    </dd>
-		<dd>Check that your back to the PowerShell prompt</dd>
+**Exit WSL**
 
-	<dt>Unregister the distro instance
-	    </dt>
-	    <dd>
-<pre>
+```
+logout
+```
+
+Check that your back to the PowerShell prompt.
+
+**Unregister the distro instance**
+
+```
 > wsl.exe --unregister Ubuntu-24.04
-</pre>
-	    </dd>
-		<dd>The isntance no longer listed
-<pre>
+```
+
+The instance no longer listed:
+
+```
 > wsl --list
 Windows Subsystem for Linux Distributions:
 Ubuntu (Default)
 Ubuntu-20.04
 TestUbuntuWSL
-</pre></dd>
+```
 
-</dl>
-
-<strong>If all actions produce the expected results listed, please <a href="results#add_result">submit</a> a 'passed' result.
-    If an action fails, or produces an unexpected result, please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include the bug number when you <a href="results#add_result">submit</a> your result.</strong>
-
-
-
-
+**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
+If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**

--- a/noble/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/noble/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -113,7 +113,7 @@ $ sudo apt full-upgrade
 
 Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
 
-Install a package:
+**Install a package:**
 
 ```
 $ sudo apt install hello

--- a/noble/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/noble/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -15,34 +15,14 @@ host (Windows) filesystem (if they exist):
 - `%USERPROFILE%\.cloud-init`
 - `%USERPROFILE%\.ubuntupro\cloud-init`
 
-After downloading the image, navigate to it on Windows explorer:
+**Double click to install:**
 
-**Double-click the image to start the installation**
+After downloading the image, navigate to it on Windows explorer and double-click the image file to start the installation.
 
 A new terminal window will pop-up showing the registration progress. In the end it will
-give instructions to start a new shell into the new instance. Take note of that command. For
-example (for noble):
-
-```
-> wsl.exe -d Ubuntu-24.04
-```
-
-Verify that the new instance has been registered by running the following command:
-
-```
-> wsl.exe --list --all --verbose
-NAME             STATE           VERSION
-*Ubuntu          Running         2
-Ubuntu-24.04     Stopped         2
-Ubuntu-20.04     Stopped         2
-TestUbuntuWSL    Stopped         2
-```
-
-Check the the name used in previous command appears in the list.
-
-**Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
-the new user creation. The input line should be prefilled with a user name derived from the
-current Windows user name.**
+run the first boot experience, the provisioning (OOBE) command, and eventually will prompt for
+the new user creation. **The input line should be prefilled with a user name derived from the
+current Windows user name**, but that's a suggestion, users are free to change it and hit enter.
 
 In the example below the Windows user name is ubuntu:
 

--- a/noble/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/noble/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -1,58 +1,62 @@
-<p>This case tests the implicit provisioning (double-click install) of a tar-based WSL image.</p>
+This case tests the implicit provisioning (double-click install) of a tar-based WSL image.
 
 It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
 
-Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at <a href="https://cdimages.ubuntu.com/ubuntu-wsl/">https://cdimages.ubuntu.com/ubuntu-wsl/</a>
+Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".
 
-For example for latest noble image:  <a href="https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl">https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/noble/pending/noble-wsl-amd64.wsl</a>
+For example for latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
 Make sure to download the image matching the correct release under test from the download link associated to this test case.
 
 Those images have cloud-init seeded. To make sure your environment doesn't contain any files that could
 cause cloud-init to change the expected results of this test cases, remove the following directories on the
 host (Windows) filesystem (if they exist):
 
-<ul>
-	<li>%USERPROFILE%\.cloud-init</li>
-	<li>%USERPROFILE%\.ubuntupro\cloud-init</li>
-</ul>
+- `%USERPROFILE%\.cloud-init`
+- `%USERPROFILE%\.ubuntupro\cloud-init`
 
 After downloading the image, navigate to it on Windows explorer:
 
-<dl>
-	<dt>Double-click the image to start the installation</dt>
-		<dd>A new terminal window will pop-up showing the registration progress. In the end it will
-		give instructions to start a new shell into the new instance. Take note of that command. For
-		example (for noble):
-<pre>
+**Double-click the image to start the installation**
+
+A new terminal window will pop-up showing the registration progress. In the end it will
+give instructions to start a new shell into the new instance. Take note of that command. For
+example (for noble):
+
+```
 > wsl.exe -d Ubuntu-24.04
-</pre>
-		</dd>
-		<dd>Verify that the new instance has been registered by running the following command:
-<pre>
+```
+
+Verify that the new instance has been registered by running the following command:
+
+```
 > wsl.exe --list --all --verbose
 NAME             STATE           VERSION
 *Ubuntu          Running         2
 Ubuntu-24.04     Stopped         2
 Ubuntu-20.04     Stopped         2
 TestUbuntuWSL    Stopped         2
-</pre>
-		</dd>
-		<dd>Check the the name used in previous command appears in the list.</dd>
+```
 
-	<dt>Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
-		the new user creation. The input line should be prefilled with a user name derived from the
-		current Windows user name.</dt>
-		<dd>In the example below the Windows user name is ubuntu
-<pre>
+Check the the name used in previous command appears in the list.
+
+**Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
+the new user creation. The input line should be prefilled with a user name derived from the
+current Windows user name.**
+
+In the example below the Windows user name is ubuntu:
+
+```
 > wsl -d Ubuntu-24.04
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
-</pre></dd>
-	<dd>Hit enter and proceed with the default user creation. Once done you should be running bash inside
-	the distro instance
-<pre>
+```
+
+Hit enter and proceed with the default user creation. Once done you should be running bash inside
+the distro instance:
+
+```
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
@@ -78,91 +82,116 @@ Welcome to Ubuntu 24.04.2 LTS (GNU/Linux 5.15.167.4-microsoft-standard-WSL2 x86_
 This message is shown once a day. To disable it please create the
 /home/ubuntu/.hushlogin file.
 ubuntu@mib01:/mnt/c/Users/ubuntu$
-</pre></dd>
+```
 
-		<dd>Verify that	you're running the right distribution (point) release. For example run:
-<pre>
+Verify that you're running the right distribution (point) release. For example run:
+
+```
 $ lsb_release -a
 No LSB modules are available.
 Distributor ID: Ubuntu
 Description:    Ubuntu 24.04.2 LTS
 Release:        24.04
 Codename:       noble
-</pre> </dd>
+```
 
-	<dt>Check systemd status</dt>
-		<dd>Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
-<pre>
+**Check systemd status**
+
+Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
+
+```
 $ systemctl is-system-running
 running
 $ systemctl --failed
   UNIT LOAD ACTIVE SUB DESCRIPTION
 
   0 loaded units listed.
-</pre></dd>
+```
 
-	<dt>The default user</dt>
-		<dd>You should be logged in with the user that you just created
-<pre>
+**The default user**
+
+You should be logged in with the user that you just created:
+
+```
 $ whoami
 ubuntu
-</pre></dd>
-		<dd>Run a command as root with sudo, for instance
-<pre>$ sudo apt update</pre></dd>
-		<dd>Verify that the command ends successfully</dd>
-		<dd>Apply any update
-<pre>$ sudo apt full-upgrade</pre></dd>
-		<dd>Verify that the command ends successfully and that any packge that must be upgraded has been upgraded</dd>
-		<dd>Install a package
-<pre>$ sudo apt install hello</pre></dd>
-		<dd>Verify that the package has been successfully installed and the application can run
-<pre>
+```
+
+Run a command as root with sudo, for instance:
+
+```
+$ sudo apt update
+```
+
+Verify that the command ends successfully.
+
+Apply any update:
+
+```
+$ sudo apt full-upgrade
+```
+
+Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
+
+Install a package:
+
+```
+$ sudo apt install hello
+```
+
+Verify that the package has been successfully installed and the application can run:
+
+```
 $ hello
 Hello, world!
-</pre></dd>
+```
 
-	<dt>Install and run graphical applications
-	    </dt>
-	    <dd>
-<pre>
+**Install and run graphical applications**
+
+```
 $ sudo apt install x11-apps gtk-4-examples
 [...]
-</pre>
-	    </dd>
-		<dd>Start one of the graphical application from the x11-apps package, like xcalc for example:
-<pre>
+```
+
+Start one of the graphical application from the x11-apps package, like xcalc for example:
+
+```
 $ xcalc
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the default backend:
-<pre>
+Start the GTK demo application with the default backend:
+
+```
 $ gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the Wayland backend:
-<pre>
+Start the GTK demo application with the Wayland backend:
+
+```
 $ GDK_BACKEND=wayland gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre>
-		It's possible that it fails due <a href="https://github.com/microsoft/WSL/issues/11261">this
-			WSL bug</a>. To confirm that try again with a different XDG_RUNTIME_DIR as below:
-<pre>
+```
+
+It's possible that it fails due [this WSL bug](https://github.com/microsoft/WSL/issues/11261). To confirm that try again with a different XDG_RUNTIME_DIR as below:
+
+```
 $ GDK_BACKEND=wayland XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre>
-		</dd>
+```
 
-	<dt>Check that Windows interoperability is still working
-	</dt>
-		<dd> Launch a Windows application
-<pre>
+**Check that Windows interoperability is still working**
+
+Launch a Windows application:
+
+```
 > notepad.exe # It should open.
-</pre>
-		</dd>
-		<dd> List the contents of the C:\Windows
-<pre>
+```
+
+List the contents of the `C:\Windows`:
+
+```
 > ls -l /mnt/c/Windows
 dr-xr-xr-x 1 root root     512 Feb 11 08:58  AppReadiness
 dr-xr-xr-x 1 root root     512 Apr  1  2024  Boot
@@ -170,35 +199,31 @@ dr-xr-xr-x 1 root root     512 Apr  1  2024  Branding
 dr-xr-xr-x 1 root root     512 Oct  7 14:37  BrowserCore
 dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 [...]
-</pre>
-		</dd>
+```
 
-	<dt>Exit WSL
-	    </dt>
-	    <dd>
-<pre>logout</pre>
-	    </dd>
-		<dd>Check that your back to the PowerShell prompt</dd>
+**Exit WSL**
 
-	<dt>Unregister the distro instance
-	    </dt>
-	    <dd>
-<pre>
+```
+logout
+```
+
+Check that your back to the PowerShell prompt.
+
+**Unregister the distro instance**
+
+```
 > wsl.exe --unregister Ubuntu-24.04
-</pre>
-	    </dd>
-		<dd>The isntance no longer listed
-<pre>
+```
+
+The instance no longer listed:
+
+```
 > wsl --list
 Windows Subsystem for Linux Distributions:
 Ubuntu (Default)
 Ubuntu-20.04
 TestUbuntuWSL
-</pre></dd>
+```
 
-</dl>
-
-<strong>If all actions produce the expected results listed, please <a href="results#add_result">submit</a> a 'passed' result.
-    If an action fails, or produces an unexpected result, please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include the bug number when you <a href="results#add_result">submit</a> your result.</strong>
-
-
+**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
+If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**

--- a/noble/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/noble/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -225,5 +225,8 @@ Ubuntu-20.04
 TestUbuntuWSL
 ```
 
-**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
-If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**
+---- 
+
+**If all actions produce the expected results listed, please submit a `passed` result.** 
+
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/noble/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/noble/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -164,7 +164,7 @@ $ sudo apt install x11-apps gtk-4-examples
 [...]
 ```
 
-Start one of the graphical application from the x11-apps package, like xcalc for example:
+Start one of the graphical applications from the x11-apps package, like xcalc for example:
 
 ```
 $ xcalc

--- a/noble/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/noble/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -1,6 +1,6 @@
 This case tests the implicit provisioning (double-click install) of a tar-based WSL image.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.5.7 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/noble/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/noble/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -27,7 +27,6 @@ current Windows user name**, but that's a suggestion, users are free to change i
 In the example below the Windows user name is ubuntu:
 
 ```
-> wsl -d Ubuntu-24.04
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
@@ -113,16 +112,48 @@ $ sudo apt full-upgrade
 
 Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
 
-**Install a package:**
+**Install a package**
 
 ```
 $ sudo apt install hello
 ```
 
-Verify that the package has been successfully installed and the application can run:
+Verify that the package has been successfully installed and the application can run: 
 
 ```
 $ hello
+Hello, world!
+```
+
+**Install a snap package**
+
+```
+$ sudo apt remove hello
+```
+
+Verify that the package has been successfully uninstalled and the application can run:
+
+```
+$ hello
+Command 'hello' not found, but can be installed with:
+sudo snap install hello  # version 2.10, or
+sudo apt  install hello  # version 2.10-5build1
+See 'snap info hello' for additional versions.
+```
+
+Then install the snap version:
+
+```
+$ sudo snap install hello
+```
+
+Verify that the package has been successfully installed and the application can run
+(If `/snap/bin` is not automatically added to your `PATH` then run `source /etc/profile`): 
+
+```
+$ hello
+Hello, world!
+$ snap run hello
 Hello, world!
 ```
 
@@ -160,6 +191,22 @@ It's possible that it fails due [this WSL bug](https://github.com/microsoft/WSL/
 $ GDK_BACKEND=wayland XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir gtk4-demo
 (Wait a moment until the application starts and is displayed)
 ```
+
+Try a graphical snap as well:
+
+```
+sudo snap install gnome-system-monitor
+gnome-system-monitor
+gnome-system-monitor
+libpxbackend-1.0.so: cannot open shared object file: No such file or directory
+Failed to load module: /home/user/snap/gnome-system-monitor/common/.cache/gio-modules/libgiolibproxy.so
+
+(gnome-system-monitor:6963): Gtk-WARNING **: 16:02:47.323: Trying to measure GtkButton 0x5757299c71e0 for width of 80, but it needs at least 88
+
+(gnome-system-monitor:6963): Gtk-CRITICAL **: 16:02:47.324: Allocation width too small. Tried to allocate 80x31, but GtkButton 0x5757299c71e0 needs at least 88x31.
+```
+
+_Some warnings may show up, the exact ones may depend on the application and version, but the window should render correctly and be functional_.
 
 **Check that Windows interoperability is still working**
 

--- a/noble/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/noble/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -1,6 +1,6 @@
 This case tests the implicit provisioning (double-click install) of a tar-based WSL image.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/noble/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/noble/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -187,9 +187,11 @@ dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 logout
 ```
 
-Check that your back to the PowerShell prompt.
+The terminal window will close.
 
 **Unregister the distro instance**
+
+Run the following command on a new PowerShell tab:
 
 ```
 > wsl.exe --unregister Ubuntu-24.04

--- a/noble/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/noble/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -113,7 +113,7 @@ $ sudo apt full-upgrade
 
 Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
 
-Install a package:
+**Install a package:**
 
 ```
 $ sudo apt install hello

--- a/noble/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/noble/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -2,14 +2,11 @@ This test case imports a WSL image from a rootfs and runs it.
 
 It requires a working Microsoft Windows 11 or higher installation with WSL version 2.5.7 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
-To run this test you must download the image from [http://cloud-images.ubuntu.com/](http://cloud-images.ubuntu.com/)
+Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
+and their file extension is ".wsl" instead of ".tar.gz".
 
-> Since the release of Ubuntu LTS 24.04.2 Noble Numbat, new images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
-> and their file extension is ".wsl" instead of ".tar.gz".
-
-For example for latest focal image download: [http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-wsl.rootfs.tar.gz](http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-wsl.rootfs.tar.gz)
-and for the latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
-Make sure to download the image from the download link associated to this test case.
+For example for latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
+Make sure to download the image matching the correct release under test from the download link associated to this test case.
 
 Latest releases have cloud-init seeded. To make sure your environment doesn't contain any files that could
 cause cloud-init to change the expected results of this test cases, remove the following directories on the

--- a/noble/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/noble/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -271,5 +271,8 @@ And the directory is either missing or empty:
 >
 ```
 
-**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
-If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**
+---- 
+
+**If all actions produce the expected results listed, please submit a `passed` result.** 
+
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/noble/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/noble/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -1,6 +1,6 @@
 This test case imports a WSL image from a rootfs and runs it.
 
-It requires a working Microsoft Windows 10 or higher installation with WSL2 enabled. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.5.7 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 To run this test you must download the image from [http://cloud-images.ubuntu.com/](http://cloud-images.ubuntu.com/)
 

--- a/noble/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/noble/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -184,10 +184,42 @@ Verify that the command ends successfully and that any package that must be upgr
 $ sudo apt install hello
 ```
 
-Verify that the package has been successfully installed and the application can run:
+Verify that the package has been successfully installed and the application can run: 
 
 ```
 $ hello
+Hello, world!
+```
+
+**Install a snap package**
+
+```
+$ sudo apt remove hello
+```
+
+Verify that the package has been successfully uninstalled and the application can run:
+
+```
+$ hello
+Command 'hello' not found, but can be installed with:
+sudo snap install hello  # version 2.10, or
+sudo apt  install hello  # version 2.10-5build1
+See 'snap info hello' for additional versions.
+```
+
+Then install the snap version:
+
+```
+$ sudo snap install hello
+```
+
+Verify that the package has been successfully installed and the application can run
+(If `/snap/bin` is not automatically added to your `PATH` then run `source /etc/profile`): 
+
+```
+$ hello
+Hello, world!
+$ snap run hello
 Hello, world!
 ```
 
@@ -218,6 +250,22 @@ Start the GTK demo application with the Wayland backend:
 $ GDK_BACKEND=wayland gtk4-demo
 (Wait a moment until the application starts and is displayed)
 ```
+
+Try a graphical snap as well:
+
+```
+sudo snap install gnome-system-monitor
+gnome-system-monitor
+gnome-system-monitor
+libpxbackend-1.0.so: cannot open shared object file: No such file or directory
+Failed to load module: /home/user/snap/gnome-system-monitor/common/.cache/gio-modules/libgiolibproxy.so
+
+(gnome-system-monitor:6963): Gtk-WARNING **: 16:02:47.323: Trying to measure GtkButton 0x5757299c71e0 for width of 80, but it needs at least 88
+
+(gnome-system-monitor:6963): Gtk-CRITICAL **: 16:02:47.324: Allocation width too small. Tried to allocate 80x31, but GtkButton 0x5757299c71e0 needs at least 88x31.
+```
+
+_Some warnings may show up, the exact ones may depend on the application and version, but the window should render correctly and be functional_.
 
 **Check that Windows interoperability is still working**
 

--- a/noble/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/noble/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -60,8 +60,7 @@ Release:        20.04
 Codename:       focal
 ```
 
-**Since Jammy (22.04) systemd is also enabled by default, so make sure it's running and that there are no
-failed units:**
+Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
 
 ```
 $ systemctl is-system-running

--- a/noble/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/noble/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -1,46 +1,40 @@
-<p>This test case imports a WSL image from a rootfs and runs it.</p>
+This test case imports a WSL image from a rootfs and runs it.
 
 It requires a working Microsoft Windows 10 or higher installation with WSL2 enabled. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
 
-To run this test you must download the image from <a href="http://cloud-images.ubuntu.com/">http://cloud-images.ubuntu.com/</a>
+To run this test you must download the image from [http://cloud-images.ubuntu.com/](http://cloud-images.ubuntu.com/)
 
-<pre>
-Since the release of Ubuntu LTS 24.04.2 Noble Numbat, new images are found at <a href="https://cdimages.ubuntu.com/ubuntu-wsl/">https://cdimages.ubuntu.com/ubuntu-wsl/</a>
-and their file extension is ".wsl" instead of ".tar.gz".
-</pre>
+> Since the release of Ubuntu LTS 24.04.2 Noble Numbat, new images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
+> and their file extension is ".wsl" instead of ".tar.gz".
 
-For example for latest focal image download: <a
-	href="http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-wsl.rootfs.tar.gz">http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-wsl.rootfs.tar.gz</a>
-and for the latest noble image:  <a href="https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl">https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/noble/pending/noble-wsl-amd64.wsl</a>
+For example for latest focal image download: [http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-wsl.rootfs.tar.gz](http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-wsl.rootfs.tar.gz)
+and for the latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
 Make sure to download the image from the download link associated to this test case.
 
 Latest releases have cloud-init seeded. To make sure your environment doesn't contain any files that could
 cause cloud-init to change the expected results of this test cases, remove the following directories on the
 host (Windows) filesystem (if they exist):
 
-<ul>
-<li>%USERPROFILE%\.cloud-init</li>
-<li>%USERPROFILE%\.ubuntupro\cloud-init</li>
-</ul>
-
+- `%USERPROFILE%\.cloud-init`
+- `%USERPROFILE%\.ubuntupro\cloud-init`
 
 Open Windows Terminal or PowerShell and execute the test case below:
 
-<dl>
-	<dt>Import the image in WSL
-	    </dt>
-	    <dd>
-<pre>
-> wsl.exe --import &lt;name of the distro&gt; &lt;location to unpack rootfs&gt; &lt;rootfs&gt; [--version &lt;version of WSL&gt;]
-</pre>
-	    </dd>
-		<dd>For example:
-<pre>
+**Import the image in WSL**
+
+```
+> wsl.exe --import <name of the distro> <location to unpack rootfs> <rootfs> [--version <version of WSL>]
+```
+
+For example:
+
+```
 > wsl.exe --import Ubuntu20.04.3 .\wsl\ .\Downloads\focal-server-cloudimg-amd64-wsl.rootfs.tar.gz --version 2
-</pre>
-		</dd>
-		<dd>Verify that the	image has been imported by running the following command:
-<pre>
+```
+
+Verify that the image has been imported by running the following command:
+
+```
 > wsl.exe --list --all --verbose
 NAME             STATE           VERSION
 *Ubuntu          Running         2
@@ -48,68 +42,61 @@ Ubuntu20.04.3    Stopped         2
 Ubuntu-Preview   Stopped         2
 Ubuntu-20.04     Stopped         2
 TestUbuntuWSL    Stopped         2
-</pre>
-		</dd>
-		<dd>Check the the name used in previous command appears in the list.</dd>
+```
 
-	<dt>Launch the newly installed application
-	    </dt>
-	    <dd>
-<pre>
+Check the the name used in previous command appears in the list.
+
+**Launch the newly installed application**
+
+```
 > wsl -d Ubuntu20.04.3
-</pre>
-	    </dd>
-		<dd>Verify that	you're inside the WSL instance and running the right distribution. For example run:
-<pre>
+```
+
+Verify that you're inside the WSL instance and running the right distribution. For example run:
+
+```
 $ lsb_release -a
 No LSB modules are available.
 Distributor ID: Ubuntu
 Description:    Ubuntu 20.04.3 LTS
 Release:        20.04
 Codename:       focal
-</pre>
-		</dd>
+```
 
-	<dt>Since Jammy (22.04) systemd is also enabled by default, so make sure it's running and that there are no
-		failed units:
-	    </dt>
-	    <dd>
-<pre>
+**Since Jammy (22.04) systemd is also enabled by default, so make sure it's running and that there are no
+failed units:**
+
+```
 $ systemctl is-system-running
 running
 $ systemctl --failed
   UNIT LOAD ACTIVE SUB DESCRIPTION
 
   0 loaded units listed.
-</pre>
-	    </dd>
+```
 
-    <dt>Wait for cloud-init to finish its job, if it's present in the system (cloud-init is only present in recent releases):
-        </dt>
-        <dd>
-<pre>
+**Wait for cloud-init to finish its job, if it's present in the system (cloud-init is only present in recent releases):**
+
+```
 $ which cloud-init && cloud-init status --wait
 /usr/bin/cloud-init
 
 status: disabled
-</pre>
-        </dd>
+```
 
-  <dt>Since the image	has been installed directly and not with the distro launcher, you're logged in a root by default and have to create a first user manually. But first, verify that there is no other user already created by default:
-      </dt>
-      <dd>
-<pre>
+**Since the image has been installed directly and not with the distro launcher, you're logged in a root by default and have to create a first user manually. But first, verify that there is no other user already created by default:**
+
+```
 $ id 1000
 id: '1000': no such user: No such file or directory
 $ id ubuntu
 id: 'ubuntu': no such user
 $ egrep ':100[0-9]:' /etc/passwd        # should output nothing.
-</pre>
-      </dd>
-    <dt>Create a new user named 'ubuntu':
-        </dt>
-        <dd>
-<pre>
+```
+
+**Create a new user named 'ubuntu':**
+
+```
 $ adduser ubuntu
 Adding user `ubuntu' ...
 Adding new group `ubuntu' (1000) ...
@@ -127,35 +114,32 @@ Work Phone []:
 Home Phone []:
 Other []:
 Is the information correct? [Y/n]
-</pre>
-        </dd>
+```
 
-	<dt>Add the newly created user to the sudo group:
-	    </dt>
-	    <dd>
-<pre>
+**Add the newly created user to the sudo group:**
+
+```
 $ usermod -aG sudo ubuntu
-</pre>
-	    </dd>
-	<dd>Verify that you	can switch to the new user
-<pre>
+```
+
+Verify that you can switch to the new user:
+
+```
 $ su ubuntu
-To run a command as administrator (user &quot;root&quot;), use &quot;sudo &lt;command&gt;&quot;.
-See &quot;man sudo_root&quot; for details.
+To run a command as administrator (user "root"), use "sudo <command>".
+See "man sudo_root" for details.
 $ whoami
 ubuntu
-</pre>
-	</dd>
+```
 
-	<dt>Exit WSL. Type CTRL+D twice until you're back to the PowerShell prompt.</dt>
+**Exit WSL.** Type CTRL+D twice until you're back to the PowerShell prompt.
 
-	<dt>Start a WSL	session directly with the newly created user.
-	    </dt>
-	    <dd>
-<pre>
-&gt; wsl -d Ubuntu20.04.3 -u ubuntu
-To run a command as administrator (user &quot;root&quot;), use &quot;sudo &lt;command&gt;&quot;.
-See &quot;man sudo_root&quot; for details.
+**Start a WSL session directly with the newly created user.**
+
+```
+> wsl -d Ubuntu20.04.3 -u ubuntu
+To run a command as administrator (user "root"), use "sudo <command>".
+See "man sudo_root" for details.
 
 Welcome to Ubuntu 20.04.3 LTS (GNU/Linux 5.10.43.3-microsoft-standard-WSL2 x86_64)
 
@@ -176,69 +160,76 @@ To see these additional updates run: apt list --upgradable
 This message is shown once a day. To disable it please create the
 /home/ubuntu/.hushlogin file.
 ubuntu@WSL:/mnt/c/Users/ubuntu$
-</pre>
-	    </dd>
+```
 
-	<dt>Run a command as root with sudo, for instance
-	    </dt>
-	    <dd>
-		<pre>$ sudo apt update</pre>
-	    </dd>
-		<dd>Verify that the	command ends successfully</dd>
+**Run a command as root with sudo, for instance**
 
-	<dt>Apply any update
-	    </dt>
-	    <dd>
-		<pre>$ sudo apt full-upgrade</pre>
-	    </dd>
-		<dd>Verify that the	command ends successfully and that any packge that must be upgraded has been upgraded</dd>
+```
+$ sudo apt update
+```
 
-	<dt>Install a package
-	    </dt>
-	    <dd>
-		<pre>$ sudo apt install hello</pre>
-	    </dd>
-		<dd>Verify that the	package has been successfully installed and the application can run<dd>
-<pre>
+Verify that the command ends successfully.
+
+**Apply any update**
+
+```
+$ sudo apt full-upgrade
+```
+
+Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
+
+**Install a package**
+
+```
+$ sudo apt install hello
+```
+
+Verify that the package has been successfully installed and the application can run:
+
+```
 $ hello
 Hello, world!
-</pre></dd>
+```
 
-	<dt>Install and run graphical applications
-	    </dt>
-	    <dd>
-<pre>
+**Install and run graphical applications**
+
+```
 $ sudo apt install x11-apps gtk-4-examples              # gtk-3-examples for focal
 [...]
-</pre>
-	    </dd>
-		<dd>Start one of the graphical application from the x11-apps package, like xcalc for example:
-<pre>
+```
+
+Start one of the graphical application from the x11-apps package, like xcalc for example:
+
+```
 $ xcalc
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the default backend:
-<pre>
+Start the GTK demo application with the default backend:
+
+```
 $ gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the Wayland backend:
-<pre>
+Start the GTK demo application with the Wayland backend:
+
+```
 $ GDK_BACKEND=wayland gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-	<dt>Check that Windows interoperability is still working
-	</dt>
-		<dd> Launch a Windows application
-<pre>
+**Check that Windows interoperability is still working**
+
+Launch a Windows application:
+
+```
 > notepad.exe # It should open.
-</pre>
-		</dd>
-		<dd> List the contents of the C:\Windows
-<pre>
+```
+
+List the contents of the `C:\Windows`:
+
+```
 > ls -l /mnt/c/Windows
 dr-xr-xr-x 1 root root     512 Feb 11 08:58  AppReadiness
 dr-xr-xr-x 1 root root     512 Apr  1  2024  Boot
@@ -246,42 +237,39 @@ dr-xr-xr-x 1 root root     512 Apr  1  2024  Branding
 dr-xr-xr-x 1 root root     512 Oct  7 14:37  BrowserCore
 dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 [...]
-</pre>
-		</dd>
+```
 
-<dt>Exit WSL
-    </dt>
-    <dd>
-<pre>logout</pre>
-    </dd>
-	<dd>Check that your back to the PowerShell prompt</dd>
+**Exit WSL**
 
-	<dt>Unregister the distro instance
-	    </dt>
-	    <dd>
-<pre>
+```
+logout
+```
+
+Check that your back to the PowerShell prompt.
+
+**Unregister the distro instance**
+
+```
 > wsl.exe --unregister Ubuntu20.04.3
-</pre>
-	    </dd>
-		<dd>The application	is no longer listed
-<pre>
+```
+
+The application is no longer listed:
+
+```
 > wsl --list
 Windows Subsystem for Linux Distributions:
 Ubuntu (Default)
 Ubuntu-Preview
 Ubuntu-20.04
 TestUbuntuWSL
-</pre>
-		</dd>
+```
 
-		<dd>And the directory is either missing or empty.
-<pre>
-&gt; ls .\wsl
-&gt;
-</pre>
-		</dd>
-</dl>
+And the directory is either missing or empty:
 
-<strong>If all actions produce the expected results listed, please <a href="results#add_result">submit</a> a 'passed' result.
-    If an action fails, or produces an unexpected result, please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include the bug number when you <a href="results#add_result">submit</a> your result.</strong>
+```
+> ls .\wsl
+>
+```
 
+**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
+If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**

--- a/noble/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/noble/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -230,7 +230,7 @@ $ sudo apt install x11-apps gtk-4-examples              # gtk-3-examples for foc
 [...]
 ```
 
-Start one of the graphical application from the x11-apps package, like xcalc for example:
+Start one of the graphical applications from the x11-apps package, like xcalc for example:
 
 ```
 $ xcalc

--- a/noble/testsuites/WSL/Mandatory/WSL cloud-init.md
+++ b/noble/testsuites/WSL/Mandatory/WSL cloud-init.md
@@ -1,6 +1,6 @@
 This case tests provisioning tar-based WSL image with relevant cloud-config user data.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/noble/testsuites/WSL/Mandatory/WSL cloud-init.md
+++ b/noble/testsuites/WSL/Mandatory/WSL cloud-init.md
@@ -1,6 +1,6 @@
 This case tests provisioning tar-based WSL image with relevant cloud-config user data.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.5.7 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/noble/testsuites/WSL/Mandatory/WSL cloud-init.md
+++ b/noble/testsuites/WSL/Mandatory/WSL cloud-init.md
@@ -1,30 +1,29 @@
-<p>This case tests provisioning tar-based WSL image with relevant cloud-config user data.</p>
+This case tests provisioning tar-based WSL image with relevant cloud-config user data.
 
 It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
 
-Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at <a href="https://cdimages.ubuntu.com/ubuntu-wsl/">https://cdimages.ubuntu.com/ubuntu-wsl/</a>
+Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".
 
-For example for latest noble image:  <a href="https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl">https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/noble/pending/noble-wsl-amd64.wsl</a>
+For example for latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
 Make sure to download the image matching the correct release under test from the download link associated to this test case.
 
 Those images have cloud-init seeded. To make sure your environment doesn't contain any files that could
 cause cloud-init to change the expected results of this test cases, empty the following directories on the
 host (Windows) filesystem (if they exist):
 
-<ul>
-	<li>%USERPROFILE%\.cloud-init</li>
-	<li>%USERPROFILE%\.ubuntupro\cloud-init</li>
-</ul>
+- `%USERPROFILE%\.cloud-init`
+- `%USERPROFILE%\.ubuntupro\cloud-init`
 
 After downloading the image, open PowerShell and execute the test case below:
 
-<dl>
-	<dt>Prepare the user data file</dt>
-	<dd>Open a text editor of your choice, create a new file with the following contents and save it as
-		<code>%USERPROFILE%\.cloud-init\Ubuntu-24.04.user-data</code> (adjust the filename to match the
-		release version under test, here assumed to be noble):
-<pre>
+**Prepare the user data file**
+
+Open a text editor of your choice, create a new file with the following contents and save it as
+`%USERPROFILE%\.cloud-init\Ubuntu-24.04.user-data` (adjust the filename to match the
+release version under test, here assumed to be noble):
+
+```
 #cloud-config
 locale: en_GB
 users:
@@ -42,33 +41,37 @@ write_files:
     default=ubuntu
 
 packages: [hello, x11-apps, gtk-4-examples]
-</pre>
-	</dd>
-	<dt>Install a new instance from the image you downloaded
-	    </dt>
-	    <dd>
-<pre>
+```
+
+**Install a new instance from the image you downloaded**
+
+```
 > wsl.exe --install --from-file .\noble-wsl-amd64.wsl
-</pre>
-	    </dd>
-		<dd>Verify that the new instance has been registered by running the following command:
-<pre>
+```
+
+Verify that the new instance has been registered by running the following command:
+
+```
 > wsl.exe --list --all --verbose
 NAME             STATE           VERSION
 *Ubuntu          Running         2
 Ubuntu-24.04     Stopped         2
 Ubuntu-20.04     Stopped         2
 TestUbuntuWSL    Stopped         2
-</pre></dd>
+```
 
-	<dt>Launch the new instance.</dt>
-	<dd>On the Windows Start Menu open the Windows Terminal. When open, at the top, at the right side of
-		the new tab button, click on the dropdown and select the "Ubuntu-24.04" profile. A new tab
-		will appear.</dd>
-	<dd>The provisioning (OOBE) command will run and eventually will run a shell
-		with the user described in the user data file logged in.</dd>
-		<dd>In the example below the Windows user name is ubuntu
-<pre>
+**Launch the new instance.**
+
+On the Windows Start Menu open the Windows Terminal. When open, at the top, at the right side of
+the new tab button, click on the dropdown and select the "Ubuntu-24.04" profile. A new tab
+will appear.
+
+The provisioning (OOBE) command will run and eventually will run a shell
+with the user described in the user data file logged in.
+
+In the example below the Windows user name is ubuntu:
+
+```
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 To run a command as administrator (user "root"), use "sudo <command>".
@@ -90,86 +93,113 @@ Welcome to Ubuntu 24.04.2 LTS (GNU/Linux 5.15.167.4-microsoft-standard-WSL2 x86_
 This message is shown once a day. To disable it please create the
 /home/ubuntu/.hushlogin file.
 ubuntu@mib01:/mnt/c/Users/ubuntu$
-</pre></dd>
-		<dd>Read through the entire message of the day. Make sure there is no warnings nor errors coming from
-			cloud-init</dd>
-		<dd>Verify that the background and foreground colors match the Ubuntu colors and the terminal
-		icon is the Ubuntu logo.</dd>
-		<dd>Verify that the text is rendered with the Ubuntu font.</dd>
-		<dd>Verify that	you're running the right distribution (point) release. For example run:
-<pre>
+```
+
+Read through the entire message of the day. Make sure there is no warnings nor errors coming from
+cloud-init.
+
+Verify that the background and foreground colors match the Ubuntu colors and the terminal
+icon is the Ubuntu logo.
+
+Verify that the text is rendered with the Ubuntu font.
+
+Verify that you're running the right distribution (point) release. For example run:
+
+```
 $ lsb_release -a
 No LSB modules are available.
 Distributor ID: Ubuntu
 Description:    Ubuntu 24.04.2 LTS
 Release:        24.04
 Codename:       noble
-</pre> </dd>
+```
 
-	<dt>Check systemd status</dt>
-		<dd>Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
-<pre>
+**Check systemd status**
+
+Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
+
+```
 $ systemctl is-system-running
 running
 $ systemctl --failed
   UNIT LOAD ACTIVE SUB DESCRIPTION
 
   0 loaded units listed.
-</pre></dd>
+```
 
-	<dt>The default user</dt>
-		<dd>You should be logged in with the user that you just created
-<pre>
+**The default user**
+
+You should be logged in with the user that you just created:
+
+```
 $ whoami
 ubuntu
-</pre></dd>
-		<dd>Run a command as root with sudo, for instance
-<pre>$ sudo apt update</pre></dd>
-		<dd>Verify that the command ends successfully</dd>
-		<dd>Apply any update
-<pre>$ sudo apt full-upgrade</pre></dd>
-		<dd>Verify that the command ends successfully and that any packge that must be upgraded has been upgraded</dd>
+```
 
-	<dt>CLI and graphical applications installed by cloud-init</dt>
-		<dd>Verify that the "hello" package has been successfully installed and the application can run
-<pre>
+Run a command as root with sudo, for instance:
+
+```
+$ sudo apt update
+```
+
+Verify that the command ends successfully.
+
+Apply any update:
+
+```
+$ sudo apt full-upgrade
+```
+
+Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
+
+**CLI and graphical applications installed by cloud-init**
+
+Verify that the "hello" package has been successfully installed and the application can run:
+
+```
 $ hello
 Hello, world!
-</pre></dd>
-		<dd>Start one of the graphical application from the x11-apps package, like xcalc for example:
-<pre>
+```
+
+Start one of the graphical application from the x11-apps package, like xcalc for example:
+
+```
 $ xcalc
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the default backend:
-<pre>
+Start the GTK demo application with the default backend:
+
+```
 $ gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the Wayland backend:
-<pre>
+Start the GTK demo application with the Wayland backend:
+
+```
 $ GDK_BACKEND=wayland gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre>
-		It's possible that it fails due <a href="https://github.com/microsoft/WSL/issues/11261">this
-			WSL bug</a>. To confirm that try again with a different XDG_RUNTIME_DIR as below:
-<pre>
+```
+
+It's possible that it fails due [this WSL bug](https://github.com/microsoft/WSL/issues/11261). To confirm that try again with a different XDG_RUNTIME_DIR as below:
+
+```
 $ GDK_BACKEND=wayland XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre>
-		</dd>
+```
 
-	<dt>Check that Windows interoperability is still working
-	</dt>
-		<dd> Launch a Windows application
-<pre>
+**Check that Windows interoperability is still working**
+
+Launch a Windows application:
+
+```
 > notepad.exe # It should open.
-</pre>
-		</dd>
-		<dd> List the contents of the C:\Windows
-<pre>
+```
+
+List the contents of the `C:\Windows`:
+
+```
 > ls -l /mnt/c/Windows
 dr-xr-xr-x 1 root root     512 Feb 11 08:58  AppReadiness
 dr-xr-xr-x 1 root root     512 Apr  1  2024  Boot
@@ -177,35 +207,31 @@ dr-xr-xr-x 1 root root     512 Apr  1  2024  Branding
 dr-xr-xr-x 1 root root     512 Oct  7 14:37  BrowserCore
 dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 [...]
-</pre>
-		</dd>
+```
 
-	<dt>Exit WSL
-	    </dt>
-	    <dd>
-<pre>logout</pre>
-	    </dd>
-		<dd>Check that your back to the PowerShell prompt</dd>
+**Exit WSL**
 
-	<dt>Unregister the distro instance
-	    </dt>
-	    <dd>
-<pre>
+```
+logout
+```
+
+Check that your back to the PowerShell prompt.
+
+**Unregister the distro instance**
+
+```
 > wsl.exe --unregister Ubuntu-24.04
-</pre>
-	    </dd>
-		<dd>The instance is no longer listed
-<pre>
+```
+
+The instance is no longer listed:
+
+```
 > wsl --list
 Windows Subsystem for Linux Distributions:
 Ubuntu (Default)
 Ubuntu-20.04
 TestUbuntuWSL
-</pre></dd>
+```
 
-</dl>
-
-<strong>If all actions produce the expected results listed, please <a href="results#add_result">submit</a> a 'passed' result.
-    If an action fails, or produces an unexpected result, please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include the bug number when you <a href="results#add_result">submit</a> your result.</strong>
-
-
+**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
+If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**

--- a/noble/testsuites/WSL/Mandatory/WSL cloud-init.md
+++ b/noble/testsuites/WSL/Mandatory/WSL cloud-init.md
@@ -167,7 +167,7 @@ Hello, world!
 ```
 
 
-Start one of the graphical application from the x11-apps package, like xcalc for example:
+Start one of the graphical applications from the x11-apps package, like xcalc for example:
 
 ```
 $ xcalc

--- a/noble/testsuites/WSL/Mandatory/WSL cloud-init.md
+++ b/noble/testsuites/WSL/Mandatory/WSL cloud-init.md
@@ -40,7 +40,11 @@ write_files:
     [user]
     default=ubuntu
 
-packages: [hello, x11-apps, gtk-4-examples]
+packages:
+  - x11-apps
+  - gtk-4-examples
+  - snap:
+    - hello
 ```
 
 **Install a new instance from the image you downloaded**
@@ -154,12 +158,14 @@ Verify that the command ends successfully and that any package that must be upgr
 
 **CLI and graphical applications installed by cloud-init**
 
-Verify that the "hello" package has been successfully installed and the application can run:
+Verify that the "hello" package has been successfully installed and the application can run
+(If `/snap/bin` is not automatically added to your `PATH` then run `source /etc/profile`):
 
 ```
 $ hello
 Hello, world!
 ```
+
 
 Start one of the graphical application from the x11-apps package, like xcalc for example:
 
@@ -188,6 +194,24 @@ It's possible that it fails due [this WSL bug](https://github.com/microsoft/WSL/
 $ GDK_BACKEND=wayland XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir gtk4-demo
 (Wait a moment until the application starts and is displayed)
 ```
+
+**Install a snap package**
+
+Try a graphical snap such as `gnome-system-monitor`:
+
+```
+sudo snap install gnome-system-monitor
+gnome-system-monitor
+gnome-system-monitor
+libpxbackend-1.0.so: cannot open shared object file: No such file or directory
+Failed to load module: /home/user/snap/gnome-system-monitor/common/.cache/gio-modules/libgiolibproxy.so
+
+(gnome-system-monitor:6963): Gtk-WARNING **: 16:02:47.323: Trying to measure GtkButton 0x5757299c71e0 for width of 80, but it needs at least 88
+
+(gnome-system-monitor:6963): Gtk-CRITICAL **: 16:02:47.324: Allocation width too small. Tried to allocate 80x31, but GtkButton 0x5757299c71e0 needs at least 88x31.
+```
+
+_Some warnings may show up, the exact ones may depend on the application and version, but the window should render correctly and be functional_.
 
 **Check that Windows interoperability is still working**
 

--- a/noble/testsuites/WSL/Mandatory/WSL cloud-init.md
+++ b/noble/testsuites/WSL/Mandatory/WSL cloud-init.md
@@ -233,5 +233,9 @@ Ubuntu-20.04
 TestUbuntuWSL
 ```
 
-**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
-If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**
+---- 
+
+**If all actions produce the expected results listed, please submit a `passed` result.** 
+
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**
+

--- a/noble/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
+++ b/noble/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
@@ -1,6 +1,6 @@
 This case tests provisioning a tar-based WSL image as WSL 1.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.5.7 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/noble/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
+++ b/noble/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
@@ -115,7 +115,7 @@ $ sudo apt full-upgrade
 
 Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
 
-Install a package:
+**Install a package:**
 
 ```
 $ sudo apt install hello

--- a/noble/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
+++ b/noble/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
@@ -1,6 +1,6 @@
 This case tests provisioning a tar-based WSL image as WSL 1.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/noble/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
+++ b/noble/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
@@ -1,11 +1,11 @@
-<p>This case tests provisioning a tar-based WSL image as WSL 1.</p>
+This case tests provisioning a tar-based WSL image as WSL 1.
 
 It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
 
-Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at <a href="https://cdimages.ubuntu.com/ubuntu-wsl/">https://cdimages.ubuntu.com/ubuntu-wsl/</a>
+Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".
 
-For example for latest noble image:  <a href="https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl">https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/noble/pending/noble-wsl-amd64.wsl</a>
+For example for latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
 Make sure to download the image matching the correct release under test from the download link associated to this test case.
 
 WSL 1 doesn't support systemd, thus we skip checking if its running, if there are failed units. We also assume
@@ -13,39 +13,45 @@ cloud-init cannot run under such environment.
 
 After downloading the image, open PowerShell and follow the steps below:
 
-<dl>
-	<dt>Install a new instance as WSL 1</dt>
-		<dd>Navigate to the folder where you downloaded the image into and enter the following
-				command, adjusting to the correct release name under test
-<pre>
-&gt; wsl --install --from-file .\noble-wsl-amd64.wsl --location .\Noble --name Noble --version 1
-</pre>
-		</dd>
-		<dd>Verify that the new instance has been registered as WSL 1 by running the following command:
-<pre>
+**Install a new instance as WSL 1**
+
+Navigate to the folder where you downloaded the image into and enter the following
+command, adjusting to the correct release name under test:
+
+```
+> wsl --install --from-file .\noble-wsl-amd64.wsl --location .\Noble --name Noble --version 1
+```
+
+Verify that the new instance has been registered as WSL 1 by running the following command:
+
+```
 > wsl.exe --list --all --verbose
 NAME             STATE           VERSION
 *Ubuntu          Running         2
 Noble            Stopped         1
 Ubuntu-20.04     Stopped         2
 TestUbuntuWSL    Stopped         2
-</pre>
-		</dd>
-		<dd>Check the **name** used in previous command appears in the list.</dd>
+```
 
-	<dt>Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
-		the new user creation. The input line should be prefilled with a user name derived from the
-		current Windows user name.</dt>
-		<dd>In the example below the Windows user name is ubuntu
-<pre>
+Check the **name** used in previous command appears in the list.
+
+**Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
+the new user creation. The input line should be prefilled with a user name derived from the
+current Windows user name.**
+
+In the example below the Windows user name is ubuntu:
+
+```
 > wsl -d Noble
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
-</pre></dd>
-	<dd>Hit enter and proceed with the default user creation. Once done you should be running bash inside
-	the distro instance
-<pre>
+```
+
+Hit enter and proceed with the default user creation. Once done you should be running bash inside
+the distro instance:
+
+```
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
@@ -71,47 +77,68 @@ Welcome to Ubuntu 24.04.2 LTS (GNU/Linux 5.15.167.4-microsoft-standard-WSL2 x86_
 This message is shown once a day. To disable it please create the
 /home/ubuntu/.hushlogin file.
 ubuntu@mib01:/mnt/c/Users/ubuntu$
-</pre></dd>
+```
 
-		<dd>Verify that	you're running the right distribution (point) release. For example run:
-<pre>
+Verify that you're running the right distribution (point) release. For example run:
+
+```
 $ lsb_release -a
 No LSB modules are available.
 Distributor ID: Ubuntu
 Description:    Ubuntu 24.04.2 LTS
 Release:        24.04
 Codename:       noble
-</pre> </dd>
+```
 
-	<dt>The default user</dt>
-		<dd>You should be logged in with the user that you just created
-<pre>
+**The default user**
+
+You should be logged in with the user that you just created:
+
+```
 $ whoami
 ubuntu
-</pre></dd>
-		<dd>Run a command as root with sudo, for instance
-<pre>$ sudo apt update</pre></dd>
-		<dd>Verify that the command ends successfully</dd>
-		<dd>Apply any update
-<pre>$ sudo apt full-upgrade</pre></dd>
-		<dd>Verify that the command ends successfully and that any packge that must be upgraded has been upgraded</dd>
-		<dd>Install a package
-<pre>$ sudo apt install hello</pre></dd>
-		<dd>Verify that the package has been successfully installed and the application can run
-<pre>
+```
+
+Run a command as root with sudo, for instance:
+
+```
+$ sudo apt update
+```
+
+Verify that the command ends successfully.
+
+Apply any update:
+
+```
+$ sudo apt full-upgrade
+```
+
+Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
+
+Install a package:
+
+```
+$ sudo apt install hello
+```
+
+Verify that the package has been successfully installed and the application can run:
+
+```
 $ hello
 Hello, world!
-</pre></dd>
+```
 
-	<dt>Check that Windows interoperability is still working
-	</dt>
-		<dd> Launch a Windows application
-<pre>
+**Check that Windows interoperability is still working**
+
+Launch a Windows application:
+
+```
 > notepad.exe # It should open.
-</pre>
-		</dd>
-		<dd> List the contents of the C:\Windows
-<pre>
+```
+
+List the contents of the `C:\Windows`:
+
+```
 > ls -l /mnt/c/Windows
 dr-xr-xr-x 1 root root     512 Feb 11 08:58  AppReadiness
 dr-xr-xr-x 1 root root     512 Apr  1  2024  Boot
@@ -119,35 +146,31 @@ dr-xr-xr-x 1 root root     512 Apr  1  2024  Branding
 dr-xr-xr-x 1 root root     512 Oct  7 14:37  BrowserCore
 dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 [...]
-</pre>
-		</dd>
+```
 
-	<dt>Exit WSL
-	    </dt>
-	    <dd>
-<pre>logout</pre>
-	    </dd>
-		<dd>Check that your back to the PowerShell prompt</dd>
+**Exit WSL**
 
-	<dt>Unregister the distro instance
-	    </dt>
-	    <dd>
-<pre>
+```
+logout
+```
+
+Check that your back to the PowerShell prompt.
+
+**Unregister the distro instance**
+
+```
 > wsl.exe --unregister Noble
-</pre>
-	    </dd>
-		<dd>The isntance no longer listed
-<pre>
+```
+
+The instance no longer listed:
+
+```
 > wsl --list
 Windows Subsystem for Linux Distributions:
 Ubuntu (Default)
 Ubuntu-20.04
 TestUbuntuWSL
-</pre></dd>
+```
 
-</dl>
-
-<strong>If all actions produce the expected results listed, please <a href="results#add_result">submit</a> a 'passed' result.
-    If an action fails, or produces an unexpected result, please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include the bug number when you <a href="results#add_result">submit</a> your result.</strong>
-
-
+**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
+If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**

--- a/noble/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
+++ b/noble/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
@@ -172,5 +172,8 @@ Ubuntu-20.04
 TestUbuntuWSL
 ```
 
-**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
-If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**
+---- 
+
+**If all actions produce the expected results listed, please submit a `passed` result.** 
+
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/resolute/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/resolute/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -15,34 +15,14 @@ host (Windows) filesystem (if they exist):
 - `%USERPROFILE%\.cloud-init`
 - `%USERPROFILE%\.ubuntupro\cloud-init`
 
-After downloading the image, navigate to it on Windows explorer:
+**Double click to install:**
 
-**Double-click the image to start the installation**
+After downloading the image, navigate to it on Windows explorer and double-click the image file to start the installation.
 
 A new terminal window will pop-up showing the registration progress. In the end it will
-give instructions to start a new shell into the new instance. Take note of that command. For
-example (for noble):
-
-```
-> wsl.exe -d Ubuntu-24.04
-```
-
-Verify that the new instance has been registered by running the following command:
-
-```
-> wsl.exe --list --all --verbose
-NAME             STATE           VERSION
-*Ubuntu          Running         2
-Ubuntu-24.04     Stopped         2
-Ubuntu-20.04     Stopped         2
-TestUbuntuWSL    Stopped         2
-```
-
-Check the the name used in previous command appears in the list.
-
-**Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
-the new user creation. The input line should be prefilled with a user name derived from the
-current Windows user name.**
+run the first boot experience, the provisioning (OOBE) command, and eventually will prompt for
+the new user creation. **The input line should be prefilled with a user name derived from the
+current Windows user name**, but that's a suggestion, users are free to change it and hit enter.
 
 In the example below the Windows user name is ubuntu:
 

--- a/resolute/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/resolute/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -225,5 +225,8 @@ Ubuntu-20.04
 TestUbuntuWSL
 ```
 
-**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
-If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**
+---- 
+
+**If all actions produce the expected results listed, please submit a `passed` result.** 
+
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/resolute/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/resolute/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -1,6 +1,6 @@
 This case tests the implicit provisioning (double-click install) of a tar-based WSL image.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.5.7 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/resolute/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/resolute/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -119,10 +119,43 @@ Verify that the command ends successfully and that any package that must be upgr
 $ sudo apt install hello
 ```
 
-Verify that the package has been successfully installed and the application can run:
+Verify that the package has been successfully installed and the application can run
+(If `/snap/bin` is not automatically added to your `PATH` then run `source /etc/profile`): 
 
 ```
 $ hello
+Hello, world!
+```
+
+**Install a snap package**
+
+```
+$ sudo apt remove hello
+```
+
+Verify that the package has been successfully uninstalled and the application can run:
+
+```
+$ hello
+Command 'hello' not found, but can be installed with:
+sudo snap install hello  # version 2.10, or
+sudo apt  install hello  # version 2.10-5build1
+See 'snap info hello' for additional versions.
+```
+
+Then install the snap version:
+
+```
+$ sudo snap install hello
+```
+
+Verify that the package has been successfully installed and the application can run
+(If `/snap/bin` is not automatically added to your `PATH` then run `source /etc/profile`): 
+
+```
+$ hello
+Hello, world!
+$ snap run hello
 Hello, world!
 ```
 
@@ -160,6 +193,22 @@ It's possible that it fails due [this WSL bug](https://github.com/microsoft/WSL/
 $ GDK_BACKEND=wayland XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir gtk4-demo
 (Wait a moment until the application starts and is displayed)
 ```
+
+Try a graphical snap as well:
+
+```
+sudo snap install gnome-system-monitor
+gnome-system-monitor
+gnome-system-monitor
+libpxbackend-1.0.so: cannot open shared object file: No such file or directory
+Failed to load module: /home/user/snap/gnome-system-monitor/common/.cache/gio-modules/libgiolibproxy.so
+
+(gnome-system-monitor:6963): Gtk-WARNING **: 16:02:47.323: Trying to measure GtkButton 0x5757299c71e0 for width of 80, but it needs at least 88
+
+(gnome-system-monitor:6963): Gtk-CRITICAL **: 16:02:47.324: Allocation width too small. Tried to allocate 80x31, but GtkButton 0x5757299c71e0 needs at least 88x31.
+```
+
+_Some warnings may show up, the exact ones may depend on the application and version, but the window should render correctly and be functional_.
 
 **Check that Windows interoperability is still working**
 

--- a/resolute/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/resolute/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -166,7 +166,7 @@ $ sudo apt install x11-apps gtk-4-examples libgles2
 [...]
 ```
 
-Start one of the graphical application from the x11-apps package, like xcalc for example:
+Start one of the graphical applications from the x11-apps package, like xcalc for example:
 
 ```
 $ xcalc

--- a/resolute/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/resolute/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -1,6 +1,6 @@
 This case tests the implicit provisioning (double-click install) of a tar-based WSL image.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/resolute/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/resolute/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -187,9 +187,11 @@ dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 logout
 ```
 
-Check that your back to the PowerShell prompt.
+The terminal window will close.
 
 **Unregister the distro instance**
+
+Run the following command on a new PowerShell tab:
 
 ```
 > wsl.exe --unregister Ubuntu-24.04

--- a/resolute/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/resolute/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -1,58 +1,62 @@
-<p>This case tests the implicit provisioning (double-click install) of a tar-based WSL image.</p>
+This case tests the implicit provisioning (double-click install) of a tar-based WSL image.
 
 It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
 
-Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at <a href="https://cdimages.ubuntu.com/ubuntu-wsl/">https://cdimages.ubuntu.com/ubuntu-wsl/</a>
+Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".
 
-For example for latest noble image:  <a href="https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl">https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/noble/pending/noble-wsl-amd64.wsl</a>
+For example for latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
 Make sure to download the image matching the correct release under test from the download link associated to this test case.
 
 Those images have cloud-init seeded. To make sure your environment doesn't contain any files that could
 cause cloud-init to change the expected results of this test cases, remove the following directories on the
 host (Windows) filesystem (if they exist):
 
-<ul>
-	<li>%USERPROFILE%\.cloud-init</li>
-	<li>%USERPROFILE%\.ubuntupro\cloud-init</li>
-</ul>
+- `%USERPROFILE%\.cloud-init`
+- `%USERPROFILE%\.ubuntupro\cloud-init`
 
 After downloading the image, navigate to it on Windows explorer:
 
-<dl>
-	<dt>Double-click the image to start the installation</dt>
-		<dd>A new terminal window will pop-up showing the registration progress. In the end it will
-		give instructions to start a new shell into the new instance. Take note of that command. For
-		example (for noble):
-<pre>
+**Double-click the image to start the installation**
+
+A new terminal window will pop-up showing the registration progress. In the end it will
+give instructions to start a new shell into the new instance. Take note of that command. For
+example (for noble):
+
+```
 > wsl.exe -d Ubuntu-24.04
-</pre>
-		</dd>
-		<dd>Verify that the new instance has been registered by running the following command:
-<pre>
+```
+
+Verify that the new instance has been registered by running the following command:
+
+```
 > wsl.exe --list --all --verbose
 NAME             STATE           VERSION
 *Ubuntu          Running         2
 Ubuntu-24.04     Stopped         2
 Ubuntu-20.04     Stopped         2
 TestUbuntuWSL    Stopped         2
-</pre>
-		</dd>
-		<dd>Check the the name used in previous command appears in the list.</dd>
+```
 
-	<dt>Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
-		the new user creation. The input line should be prefilled with a user name derived from the
-		current Windows user name.</dt>
-		<dd>In the example below the Windows user name is ubuntu
-<pre>
+Check the the name used in previous command appears in the list.
+
+**Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
+the new user creation. The input line should be prefilled with a user name derived from the
+current Windows user name.**
+
+In the example below the Windows user name is ubuntu:
+
+```
 > wsl -d Ubuntu-24.04
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
-</pre></dd>
-	<dd>Hit enter and proceed with the default user creation. Once done you should be running bash inside
-	the distro instance
-<pre>
+```
+
+Hit enter and proceed with the default user creation. Once done you should be running bash inside
+the distro instance:
+
+```
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
@@ -78,91 +82,116 @@ Welcome to Ubuntu 24.04.2 LTS (GNU/Linux 5.15.167.4-microsoft-standard-WSL2 x86_
 This message is shown once a day. To disable it please create the
 /home/ubuntu/.hushlogin file.
 ubuntu@mib01:/mnt/c/Users/ubuntu$
-</pre></dd>
+```
 
-		<dd>Verify that	you're running the right distribution (point) release. For example run:
-<pre>
+Verify that you're running the right distribution (point) release. For example run:
+
+```
 $ lsb_release -a
 No LSB modules are available.
 Distributor ID: Ubuntu
 Description:    Ubuntu 24.04.2 LTS
 Release:        24.04
 Codename:       noble
-</pre> </dd>
+```
 
-	<dt>Check systemd status</dt>
-		<dd>Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
-<pre>
+**Check systemd status**
+
+Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
+
+```
 $ systemctl is-system-running
 running
 $ systemctl --failed
   UNIT LOAD ACTIVE SUB DESCRIPTION
 
   0 loaded units listed.
-</pre></dd>
+```
 
-	<dt>The default user</dt>
-		<dd>You should be logged in with the user that you just created
-<pre>
+**The default user**
+
+You should be logged in with the user that you just created:
+
+```
 $ whoami
 ubuntu
-</pre></dd>
-		<dd>Run a command as root with sudo, for instance
-<pre>$ sudo apt update</pre></dd>
-		<dd>Verify that the command ends successfully</dd>
-		<dd>Apply any update
-<pre>$ sudo apt full-upgrade</pre></dd>
-		<dd>Verify that the command ends successfully and that any packge that must be upgraded has been upgraded</dd>
-		<dd>Install a package
-<pre>$ sudo apt install hello</pre></dd>
-		<dd>Verify that the package has been successfully installed and the application can run
-<pre>
+```
+
+Run a command as root with sudo, for instance:
+
+```
+$ sudo apt update
+```
+
+Verify that the command ends successfully.
+
+Apply any update:
+
+```
+$ sudo apt full-upgrade
+```
+
+Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
+
+Install a package:
+
+```
+$ sudo apt install hello
+```
+
+Verify that the package has been successfully installed and the application can run:
+
+```
 $ hello
 Hello, world!
-</pre></dd>
+```
 
-	<dt>Install and run graphical applications
-	    </dt>
-	    <dd>
-<pre>
+**Install and run graphical applications**
+
+```
 $ sudo apt install x11-apps gtk-4-examples libgles2
 [...]
-</pre>
-	    </dd>
-		<dd>Start one of the graphical application from the x11-apps package, like xcalc for example:
-<pre>
+```
+
+Start one of the graphical application from the x11-apps package, like xcalc for example:
+
+```
 $ xcalc
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the default backend:
-<pre>
+Start the GTK demo application with the default backend:
+
+```
 $ gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the Wayland backend:
-<pre>
+Start the GTK demo application with the Wayland backend:
+
+```
 $ GDK_BACKEND=wayland gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre>
-		It's possible that it fails due <a href="https://github.com/microsoft/WSL/issues/11261">this
-			WSL bug</a>. To confirm that try again with a different XDG_RUNTIME_DIR as below:
-<pre>
+```
+
+It's possible that it fails due [this WSL bug](https://github.com/microsoft/WSL/issues/11261). To confirm that try again with a different XDG_RUNTIME_DIR as below:
+
+```
 $ GDK_BACKEND=wayland XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre>
-		</dd>
+```
 
-	<dt>Check that Windows interoperability is still working
-	</dt>
-		<dd> Launch a Windows application
-<pre>
+**Check that Windows interoperability is still working**
+
+Launch a Windows application:
+
+```
 > notepad.exe # It should open.
-</pre>
-		</dd>
-		<dd> List the contents of the C:\Windows
-<pre>
+```
+
+List the contents of the `C:\Windows`:
+
+```
 > ls -l /mnt/c/Windows
 dr-xr-xr-x 1 root root     512 Feb 11 08:58  AppReadiness
 dr-xr-xr-x 1 root root     512 Apr  1  2024  Boot
@@ -170,37 +199,31 @@ dr-xr-xr-x 1 root root     512 Apr  1  2024  Branding
 dr-xr-xr-x 1 root root     512 Oct  7 14:37  BrowserCore
 dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 [...]
-</pre>
-		</dd>
+```
 
-	<dt>Exit WSL
-	    </dt>
-	    <dd>
-<pre>logout</pre>
-	    </dd>
-		<dd>Check that your back to the PowerShell prompt</dd>
+**Exit WSL**
 
-	<dt>Unregister the distro instance
-	    </dt>
-	    <dd>
-<pre>
+```
+logout
+```
+
+Check that your back to the PowerShell prompt.
+
+**Unregister the distro instance**
+
+```
 > wsl.exe --unregister Ubuntu-24.04
-</pre>
-	    </dd>
-		<dd>The isntance no longer listed
-<pre>
+```
+
+The instance no longer listed:
+
+```
 > wsl --list
 Windows Subsystem for Linux Distributions:
 Ubuntu (Default)
 Ubuntu-20.04
 TestUbuntuWSL
-</pre></dd>
+```
 
-</dl>
-
-<strong>If all actions produce the expected results listed, please <a href="results#add_result">submit</a> a 'passed' result.
-    If an action fails, or produces an unexpected result, please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include the bug number when you <a href="results#add_result">submit</a> your result.</strong>
-
-
-
-
+**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
+If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**

--- a/resolute/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/resolute/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -113,7 +113,7 @@ $ sudo apt full-upgrade
 
 Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
 
-Install a package:
+**Install a package:**
 
 ```
 $ sudo apt install hello

--- a/resolute/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -15,34 +15,14 @@ host (Windows) filesystem (if they exist):
 - `%USERPROFILE%\.cloud-init`
 - `%USERPROFILE%\.ubuntupro\cloud-init`
 
-After downloading the image, navigate to it on Windows explorer:
+**Double click to install:**
 
-**Double-click the image to start the installation**
+After downloading the image, navigate to it on Windows explorer and double-click the image file to start the installation.
 
 A new terminal window will pop-up showing the registration progress. In the end it will
-give instructions to start a new shell into the new instance. Take note of that command. For
-example (for noble):
-
-```
-> wsl.exe -d Ubuntu-24.04
-```
-
-Verify that the new instance has been registered by running the following command:
-
-```
-> wsl.exe --list --all --verbose
-NAME             STATE           VERSION
-*Ubuntu          Running         2
-Ubuntu-24.04     Stopped         2
-Ubuntu-20.04     Stopped         2
-TestUbuntuWSL    Stopped         2
-```
-
-Check the the name used in previous command appears in the list.
-
-**Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
-the new user creation. The input line should be prefilled with a user name derived from the
-current Windows user name.**
+run the first boot experience, the provisioning (OOBE) command, and eventually will prompt for
+the new user creation. **The input line should be prefilled with a user name derived from the
+current Windows user name**, but that's a suggestion, users are free to change it and hit enter.
 
 In the example below the Windows user name is ubuntu:
 

--- a/resolute/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -1,58 +1,62 @@
-<p>This case tests the implicit provisioning (double-click install) of a tar-based WSL image.</p>
+This case tests the implicit provisioning (double-click install) of a tar-based WSL image.
 
 It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
 
-Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at <a href="https://cdimages.ubuntu.com/ubuntu-wsl/">https://cdimages.ubuntu.com/ubuntu-wsl/</a>
+Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".
 
-For example for latest noble image:  <a href="https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl">https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/noble/pending/noble-wsl-amd64.wsl</a>
+For example for latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
 Make sure to download the image matching the correct release under test from the download link associated to this test case.
 
 Those images have cloud-init seeded. To make sure your environment doesn't contain any files that could
 cause cloud-init to change the expected results of this test cases, remove the following directories on the
 host (Windows) filesystem (if they exist):
 
-<ul>
-	<li>%USERPROFILE%\.cloud-init</li>
-	<li>%USERPROFILE%\.ubuntupro\cloud-init</li>
-</ul>
+- `%USERPROFILE%\.cloud-init`
+- `%USERPROFILE%\.ubuntupro\cloud-init`
 
 After downloading the image, navigate to it on Windows explorer:
 
-<dl>
-	<dt>Double-click the image to start the installation</dt>
-		<dd>A new terminal window will pop-up showing the registration progress. In the end it will
-		give instructions to start a new shell into the new instance. Take note of that command. For
-		example (for noble):
-<pre>
+**Double-click the image to start the installation**
+
+A new terminal window will pop-up showing the registration progress. In the end it will
+give instructions to start a new shell into the new instance. Take note of that command. For
+example (for noble):
+
+```
 > wsl.exe -d Ubuntu-24.04
-</pre>
-		</dd>
-		<dd>Verify that the new instance has been registered by running the following command:
-<pre>
+```
+
+Verify that the new instance has been registered by running the following command:
+
+```
 > wsl.exe --list --all --verbose
 NAME             STATE           VERSION
 *Ubuntu          Running         2
 Ubuntu-24.04     Stopped         2
 Ubuntu-20.04     Stopped         2
 TestUbuntuWSL    Stopped         2
-</pre>
-		</dd>
-		<dd>Check the the name used in previous command appears in the list.</dd>
+```
 
-	<dt>Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
-		the new user creation. The input line should be prefilled with a user name derived from the
-		current Windows user name.</dt>
-		<dd>In the example below the Windows user name is ubuntu
-<pre>
+Check the the name used in previous command appears in the list.
+
+**Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
+the new user creation. The input line should be prefilled with a user name derived from the
+current Windows user name.**
+
+In the example below the Windows user name is ubuntu:
+
+```
 > wsl -d Ubuntu-24.04
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
-</pre></dd>
-	<dd>Hit enter and proceed with the default user creation. Once done you should be running bash inside
-	the distro instance
-<pre>
+```
+
+Hit enter and proceed with the default user creation. Once done you should be running bash inside
+the distro instance:
+
+```
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
@@ -78,91 +82,116 @@ Welcome to Ubuntu 24.04.2 LTS (GNU/Linux 5.15.167.4-microsoft-standard-WSL2 x86_
 This message is shown once a day. To disable it please create the
 /home/ubuntu/.hushlogin file.
 ubuntu@mib01:/mnt/c/Users/ubuntu$
-</pre></dd>
+```
 
-		<dd>Verify that	you're running the right distribution (point) release. For example run:
-<pre>
+Verify that you're running the right distribution (point) release. For example run:
+
+```
 $ lsb_release -a
 No LSB modules are available.
 Distributor ID: Ubuntu
 Description:    Ubuntu 24.04.2 LTS
 Release:        24.04
 Codename:       noble
-</pre> </dd>
+```
 
-	<dt>Check systemd status</dt>
-		<dd>Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
-<pre>
+**Check systemd status**
+
+Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
+
+```
 $ systemctl is-system-running
 running
 $ systemctl --failed
   UNIT LOAD ACTIVE SUB DESCRIPTION
 
   0 loaded units listed.
-</pre></dd>
+```
 
-	<dt>The default user</dt>
-		<dd>You should be logged in with the user that you just created
-<pre>
+**The default user**
+
+You should be logged in with the user that you just created:
+
+```
 $ whoami
 ubuntu
-</pre></dd>
-		<dd>Run a command as root with sudo, for instance
-<pre>$ sudo apt update</pre></dd>
-		<dd>Verify that the command ends successfully</dd>
-		<dd>Apply any update
-<pre>$ sudo apt full-upgrade</pre></dd>
-		<dd>Verify that the command ends successfully and that any packge that must be upgraded has been upgraded</dd>
-		<dd>Install a package
-<pre>$ sudo apt install hello</pre></dd>
-		<dd>Verify that the package has been successfully installed and the application can run
-<pre>
+```
+
+Run a command as root with sudo, for instance:
+
+```
+$ sudo apt update
+```
+
+Verify that the command ends successfully.
+
+Apply any update:
+
+```
+$ sudo apt full-upgrade
+```
+
+Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
+
+Install a package:
+
+```
+$ sudo apt install hello
+```
+
+Verify that the package has been successfully installed and the application can run:
+
+```
 $ hello
 Hello, world!
-</pre></dd>
+```
 
-	<dt>Install and run graphical applications
-	    </dt>
-	    <dd>
-<pre>
+**Install and run graphical applications**
+
+```
 $ sudo apt install x11-apps gtk-4-examples
 [...]
-</pre>
-	    </dd>
-		<dd>Start one of the graphical application from the x11-apps package, like xcalc for example:
-<pre>
+```
+
+Start one of the graphical application from the x11-apps package, like xcalc for example:
+
+```
 $ xcalc
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the default backend:
-<pre>
+Start the GTK demo application with the default backend:
+
+```
 $ gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the Wayland backend:
-<pre>
+Start the GTK demo application with the Wayland backend:
+
+```
 $ GDK_BACKEND=wayland gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre>
-		It's possible that it fails due <a href="https://github.com/microsoft/WSL/issues/11261">this
-			WSL bug</a>. To confirm that try again with a different XDG_RUNTIME_DIR as below:
-<pre>
+```
+
+It's possible that it fails due [this WSL bug](https://github.com/microsoft/WSL/issues/11261). To confirm that try again with a different XDG_RUNTIME_DIR as below:
+
+```
 $ GDK_BACKEND=wayland XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre>
-		</dd>
+```
 
-	<dt>Check that Windows interoperability is still working
-	</dt>
-		<dd> Launch a Windows application
-<pre>
+**Check that Windows interoperability is still working**
+
+Launch a Windows application:
+
+```
 > notepad.exe # It should open.
-</pre>
-		</dd>
-		<dd> List the contents of the C:\Windows
-<pre>
+```
+
+List the contents of the `C:\Windows`:
+
+```
 > ls -l /mnt/c/Windows
 dr-xr-xr-x 1 root root     512 Feb 11 08:58  AppReadiness
 dr-xr-xr-x 1 root root     512 Apr  1  2024  Boot
@@ -170,35 +199,31 @@ dr-xr-xr-x 1 root root     512 Apr  1  2024  Branding
 dr-xr-xr-x 1 root root     512 Oct  7 14:37  BrowserCore
 dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 [...]
-</pre>
-		</dd>
+```
 
-	<dt>Exit WSL
-	    </dt>
-	    <dd>
-<pre>logout</pre>
-	    </dd>
-		<dd>Check that your back to the PowerShell prompt</dd>
+**Exit WSL**
 
-	<dt>Unregister the distro instance
-	    </dt>
-	    <dd>
-<pre>
+```
+logout
+```
+
+Check that your back to the PowerShell prompt.
+
+**Unregister the distro instance**
+
+```
 > wsl.exe --unregister Ubuntu-24.04
-</pre>
-	    </dd>
-		<dd>The isntance no longer listed
-<pre>
+```
+
+The instance no longer listed:
+
+```
 > wsl --list
 Windows Subsystem for Linux Distributions:
 Ubuntu (Default)
 Ubuntu-20.04
 TestUbuntuWSL
-</pre></dd>
+```
 
-</dl>
-
-<strong>If all actions produce the expected results listed, please <a href="results#add_result">submit</a> a 'passed' result.
-    If an action fails, or produces an unexpected result, please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include the bug number when you <a href="results#add_result">submit</a> your result.</strong>
-
-
+**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
+If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**

--- a/resolute/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -225,5 +225,8 @@ Ubuntu-20.04
 TestUbuntuWSL
 ```
 
-**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
-If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**
+---- 
+
+**If all actions produce the expected results listed, please submit a `passed` result.** 
+
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/resolute/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -164,7 +164,7 @@ $ sudo apt install x11-apps gtk-4-examples
 [...]
 ```
 
-Start one of the graphical application from the x11-apps package, like xcalc for example:
+Start one of the graphical applications from the x11-apps package, like xcalc for example:
 
 ```
 $ xcalc

--- a/resolute/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -1,6 +1,6 @@
 This case tests the implicit provisioning (double-click install) of a tar-based WSL image.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.5.7 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/resolute/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -27,7 +27,6 @@ current Windows user name**, but that's a suggestion, users are free to change i
 In the example below the Windows user name is ubuntu:
 
 ```
-> wsl -d Ubuntu-24.04
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
@@ -113,16 +112,48 @@ $ sudo apt full-upgrade
 
 Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
 
-**Install a package:**
+**Install a package**
 
 ```
 $ sudo apt install hello
 ```
 
-Verify that the package has been successfully installed and the application can run:
+Verify that the package has been successfully installed and the application can run: 
 
 ```
 $ hello
+Hello, world!
+```
+
+**Install a snap package**
+
+```
+$ sudo apt remove hello
+```
+
+Verify that the package has been successfully uninstalled and the application can run:
+
+```
+$ hello
+Command 'hello' not found, but can be installed with:
+sudo snap install hello  # version 2.10, or
+sudo apt  install hello  # version 2.10-5build1
+See 'snap info hello' for additional versions.
+```
+
+Then install the snap version:
+
+```
+$ sudo snap install hello
+```
+
+Verify that the package has been successfully installed and the application can run
+(If `/snap/bin` is not automatically added to your `PATH` then run `source /etc/profile`): 
+
+```
+$ hello
+Hello, world!
+$ snap run hello
 Hello, world!
 ```
 
@@ -160,6 +191,22 @@ It's possible that it fails due [this WSL bug](https://github.com/microsoft/WSL/
 $ GDK_BACKEND=wayland XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir gtk4-demo
 (Wait a moment until the application starts and is displayed)
 ```
+
+Try a graphical snap as well:
+
+```
+sudo snap install gnome-system-monitor
+gnome-system-monitor
+gnome-system-monitor
+libpxbackend-1.0.so: cannot open shared object file: No such file or directory
+Failed to load module: /home/user/snap/gnome-system-monitor/common/.cache/gio-modules/libgiolibproxy.so
+
+(gnome-system-monitor:6963): Gtk-WARNING **: 16:02:47.323: Trying to measure GtkButton 0x5757299c71e0 for width of 80, but it needs at least 88
+
+(gnome-system-monitor:6963): Gtk-CRITICAL **: 16:02:47.324: Allocation width too small. Tried to allocate 80x31, but GtkButton 0x5757299c71e0 needs at least 88x31.
+```
+
+_Some warnings may show up, the exact ones may depend on the application and version, but the window should render correctly and be functional_.
 
 **Check that Windows interoperability is still working**
 

--- a/resolute/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -1,6 +1,6 @@
 This case tests the implicit provisioning (double-click install) of a tar-based WSL image.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/resolute/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -187,9 +187,11 @@ dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 logout
 ```
 
-Check that your back to the PowerShell prompt.
+The terminal window will close.
 
 **Unregister the distro instance**
+
+Run the following command on a new PowerShell tab:
 
 ```
 > wsl.exe --unregister Ubuntu-24.04

--- a/resolute/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -113,7 +113,7 @@ $ sudo apt full-upgrade
 
 Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
 
-Install a package:
+**Install a package:**
 
 ```
 $ sudo apt install hello

--- a/resolute/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -2,14 +2,11 @@ This test case imports a WSL image from a rootfs and runs it.
 
 It requires a working Microsoft Windows 11 or higher installation with WSL version 2.5.7 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
-To run this test you must download the image from [http://cloud-images.ubuntu.com/](http://cloud-images.ubuntu.com/)
+Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
+and their file extension is ".wsl" instead of ".tar.gz".
 
-> Since the release of Ubuntu LTS 24.04.2 Noble Numbat, new images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
-> and their file extension is ".wsl" instead of ".tar.gz".
-
-For example for latest focal image download: [http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-wsl.rootfs.tar.gz](http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-wsl.rootfs.tar.gz)
-and for the latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
-Make sure to download the image from the download link associated to this test case.
+For example for latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
+Make sure to download the image matching the correct release under test from the download link associated to this test case.
 
 Latest releases have cloud-init seeded. To make sure your environment doesn't contain any files that could
 cause cloud-init to change the expected results of this test cases, remove the following directories on the

--- a/resolute/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -271,5 +271,8 @@ And the directory is either missing or empty:
 >
 ```
 
-**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
-If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**
+---- 
+
+**If all actions produce the expected results listed, please submit a `passed` result.** 
+
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/resolute/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -1,6 +1,6 @@
 This test case imports a WSL image from a rootfs and runs it.
 
-It requires a working Microsoft Windows 10 or higher installation with WSL2 enabled. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.5.7 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 To run this test you must download the image from [http://cloud-images.ubuntu.com/](http://cloud-images.ubuntu.com/)
 

--- a/resolute/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -184,10 +184,42 @@ Verify that the command ends successfully and that any package that must be upgr
 $ sudo apt install hello
 ```
 
-Verify that the package has been successfully installed and the application can run:
+Verify that the package has been successfully installed and the application can run: 
 
 ```
 $ hello
+Hello, world!
+```
+
+**Install a snap package**
+
+```
+$ sudo apt remove hello
+```
+
+Verify that the package has been successfully uninstalled and the application can run:
+
+```
+$ hello
+Command 'hello' not found, but can be installed with:
+sudo snap install hello  # version 2.10, or
+sudo apt  install hello  # version 2.10-5build1
+See 'snap info hello' for additional versions.
+```
+
+Then install the snap version:
+
+```
+$ sudo snap install hello
+```
+
+Verify that the package has been successfully installed and the application can run
+(If `/snap/bin` is not automatically added to your `PATH` then run `source /etc/profile`): 
+
+```
+$ hello
+Hello, world!
+$ snap run hello
 Hello, world!
 ```
 
@@ -218,6 +250,22 @@ Start the GTK demo application with the Wayland backend:
 $ GDK_BACKEND=wayland gtk4-demo
 (Wait a moment until the application starts and is displayed)
 ```
+
+Try a graphical snap as well:
+
+```
+sudo snap install gnome-system-monitor
+gnome-system-monitor
+gnome-system-monitor
+libpxbackend-1.0.so: cannot open shared object file: No such file or directory
+Failed to load module: /home/user/snap/gnome-system-monitor/common/.cache/gio-modules/libgiolibproxy.so
+
+(gnome-system-monitor:6963): Gtk-WARNING **: 16:02:47.323: Trying to measure GtkButton 0x5757299c71e0 for width of 80, but it needs at least 88
+
+(gnome-system-monitor:6963): Gtk-CRITICAL **: 16:02:47.324: Allocation width too small. Tried to allocate 80x31, but GtkButton 0x5757299c71e0 needs at least 88x31.
+```
+
+_Some warnings may show up, the exact ones may depend on the application and version, but the window should render correctly and be functional_.
 
 **Check that Windows interoperability is still working**
 

--- a/resolute/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -60,8 +60,7 @@ Release:        20.04
 Codename:       focal
 ```
 
-**Since Jammy (22.04) systemd is also enabled by default, so make sure it's running and that there are no
-failed units:**
+Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
 
 ```
 $ systemctl is-system-running

--- a/resolute/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -1,46 +1,40 @@
-<p>This test case imports a WSL image from a rootfs and runs it.</p>
+This test case imports a WSL image from a rootfs and runs it.
 
 It requires a working Microsoft Windows 10 or higher installation with WSL2 enabled. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
 
-To run this test you must download the image from <a href="http://cloud-images.ubuntu.com/">http://cloud-images.ubuntu.com/</a>
+To run this test you must download the image from [http://cloud-images.ubuntu.com/](http://cloud-images.ubuntu.com/)
 
-<pre>
-Since the release of Ubuntu LTS 24.04.2 Noble Numbat, new images are found at <a href="https://cdimages.ubuntu.com/ubuntu-wsl/">https://cdimages.ubuntu.com/ubuntu-wsl/</a>
-and their file extension is ".wsl" instead of ".tar.gz".
-</pre>
+> Since the release of Ubuntu LTS 24.04.2 Noble Numbat, new images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
+> and their file extension is ".wsl" instead of ".tar.gz".
 
-For example for latest focal image download: <a
-	href="http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-wsl.rootfs.tar.gz">http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-wsl.rootfs.tar.gz</a>
-and for the latest noble image:  <a href="https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl">https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/noble/pending/noble-wsl-amd64.wsl</a>
+For example for latest focal image download: [http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-wsl.rootfs.tar.gz](http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-wsl.rootfs.tar.gz)
+and for the latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
 Make sure to download the image from the download link associated to this test case.
 
 Latest releases have cloud-init seeded. To make sure your environment doesn't contain any files that could
 cause cloud-init to change the expected results of this test cases, remove the following directories on the
 host (Windows) filesystem (if they exist):
 
-<ul>
-<li>%USERPROFILE%\.cloud-init</li>
-<li>%USERPROFILE%\.ubuntupro\cloud-init</li>
-</ul>
-
+- `%USERPROFILE%\.cloud-init`
+- `%USERPROFILE%\.ubuntupro\cloud-init`
 
 Open Windows Terminal or PowerShell and execute the test case below:
 
-<dl>
-	<dt>Import the image in WSL
-	    </dt>
-	    <dd>
-<pre>
-> wsl.exe --import &lt;name of the distro&gt; &lt;location to unpack rootfs&gt; &lt;rootfs&gt; [--version &lt;version of WSL&gt;]
-</pre>
-	    </dd>
-		<dd>For example:
-<pre>
+**Import the image in WSL**
+
+```
+> wsl.exe --import <name of the distro> <location to unpack rootfs> <rootfs> [--version <version of WSL>]
+```
+
+For example:
+
+```
 > wsl.exe --import Ubuntu20.04.3 .\wsl\ .\Downloads\focal-server-cloudimg-amd64-wsl.rootfs.tar.gz --version 2
-</pre>
-		</dd>
-		<dd>Verify that the	image has been imported by running the following command:
-<pre>
+```
+
+Verify that the image has been imported by running the following command:
+
+```
 > wsl.exe --list --all --verbose
 NAME             STATE           VERSION
 *Ubuntu          Running         2
@@ -48,68 +42,61 @@ Ubuntu20.04.3    Stopped         2
 Ubuntu-Preview   Stopped         2
 Ubuntu-20.04     Stopped         2
 TestUbuntuWSL    Stopped         2
-</pre>
-		</dd>
-		<dd>Check the the name used in previous command appears in the list.</dd>
+```
 
-	<dt>Launch the newly installed application
-	    </dt>
-	    <dd>
-<pre>
+Check the the name used in previous command appears in the list.
+
+**Launch the newly installed application**
+
+```
 > wsl -d Ubuntu20.04.3
-</pre>
-	    </dd>
-		<dd>Verify that	you're inside the WSL instance and running the right distribution. For example run:
-<pre>
+```
+
+Verify that you're inside the WSL instance and running the right distribution. For example run:
+
+```
 $ lsb_release -a
 No LSB modules are available.
 Distributor ID: Ubuntu
 Description:    Ubuntu 20.04.3 LTS
 Release:        20.04
 Codename:       focal
-</pre>
-		</dd>
+```
 
-	<dt>Since Jammy (22.04) systemd is also enabled by default, so make sure it's running and that there are no
-		failed units:
-	    </dt>
-	    <dd>
-<pre>
+**Since Jammy (22.04) systemd is also enabled by default, so make sure it's running and that there are no
+failed units:**
+
+```
 $ systemctl is-system-running
 running
 $ systemctl --failed
   UNIT LOAD ACTIVE SUB DESCRIPTION
 
   0 loaded units listed.
-</pre>
-	    </dd>
+```
 
-    <dt>Wait for cloud-init to finish its job, if it's present in the system (cloud-init is only present in recent releases):
-        </dt>
-        <dd>
-<pre>
+**Wait for cloud-init to finish its job, if it's present in the system (cloud-init is only present in recent releases):**
+
+```
 $ which cloud-init && cloud-init status --wait
 /usr/bin/cloud-init
 
 status: disabled
-</pre>
-        </dd>
+```
 
-  <dt>Since the image	has been installed directly and not with the distro launcher, you're logged in a root by default and have to create a first user manually. But first, verify that there is no other user already created by default:
-      </dt>
-      <dd>
-<pre>
+**Since the image has been installed directly and not with the distro launcher, you're logged in a root by default and have to create a first user manually. But first, verify that there is no other user already created by default:**
+
+```
 $ id 1000
 id: '1000': no such user: No such file or directory
 $ id ubuntu
 id: 'ubuntu': no such user
 $ egrep ':100[0-9]:' /etc/passwd        # should output nothing.
-</pre>
-      </dd>
-    <dt>Create a new user named 'ubuntu':
-        </dt>
-        <dd>
-<pre>
+```
+
+**Create a new user named 'ubuntu':**
+
+```
 $ adduser ubuntu
 Adding user `ubuntu' ...
 Adding new group `ubuntu' (1000) ...
@@ -127,35 +114,32 @@ Work Phone []:
 Home Phone []:
 Other []:
 Is the information correct? [Y/n]
-</pre>
-        </dd>
+```
 
-	<dt>Add the newly created user to the sudo group:
-	    </dt>
-	    <dd>
-<pre>
+**Add the newly created user to the sudo group:**
+
+```
 $ usermod -aG sudo ubuntu
-</pre>
-	    </dd>
-	<dd>Verify that you	can switch to the new user
-<pre>
+```
+
+Verify that you can switch to the new user:
+
+```
 $ su ubuntu
-To run a command as administrator (user &quot;root&quot;), use &quot;sudo &lt;command&gt;&quot;.
-See &quot;man sudo_root&quot; for details.
+To run a command as administrator (user "root"), use "sudo <command>".
+See "man sudo_root" for details.
 $ whoami
 ubuntu
-</pre>
-	</dd>
+```
 
-	<dt>Exit WSL. Type CTRL+D twice until you're back to the PowerShell prompt.</dt>
+**Exit WSL.** Type CTRL+D twice until you're back to the PowerShell prompt.
 
-	<dt>Start a WSL	session directly with the newly created user.
-	    </dt>
-	    <dd>
-<pre>
-&gt; wsl -d Ubuntu20.04.3 -u ubuntu
-To run a command as administrator (user &quot;root&quot;), use &quot;sudo &lt;command&gt;&quot;.
-See &quot;man sudo_root&quot; for details.
+**Start a WSL session directly with the newly created user.**
+
+```
+> wsl -d Ubuntu20.04.3 -u ubuntu
+To run a command as administrator (user "root"), use "sudo <command>".
+See "man sudo_root" for details.
 
 Welcome to Ubuntu 20.04.3 LTS (GNU/Linux 5.10.43.3-microsoft-standard-WSL2 x86_64)
 
@@ -176,69 +160,76 @@ To see these additional updates run: apt list --upgradable
 This message is shown once a day. To disable it please create the
 /home/ubuntu/.hushlogin file.
 ubuntu@WSL:/mnt/c/Users/ubuntu$
-</pre>
-	    </dd>
+```
 
-	<dt>Run a command as root with sudo, for instance
-	    </dt>
-	    <dd>
-		<pre>$ sudo apt update</pre>
-	    </dd>
-		<dd>Verify that the	command ends successfully</dd>
+**Run a command as root with sudo, for instance**
 
-	<dt>Apply any update
-	    </dt>
-	    <dd>
-		<pre>$ sudo apt full-upgrade</pre>
-	    </dd>
-		<dd>Verify that the	command ends successfully and that any packge that must be upgraded has been upgraded</dd>
+```
+$ sudo apt update
+```
 
-	<dt>Install a package
-	    </dt>
-	    <dd>
-		<pre>$ sudo apt install hello</pre>
-	    </dd>
-		<dd>Verify that the	package has been successfully installed and the application can run<dd>
-<pre>
+Verify that the command ends successfully.
+
+**Apply any update**
+
+```
+$ sudo apt full-upgrade
+```
+
+Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
+
+**Install a package**
+
+```
+$ sudo apt install hello
+```
+
+Verify that the package has been successfully installed and the application can run:
+
+```
 $ hello
 Hello, world!
-</pre></dd>
+```
 
-	<dt>Install and run graphical applications
-	    </dt>
-	    <dd>
-<pre>
+**Install and run graphical applications**
+
+```
 $ sudo apt install x11-apps gtk-4-examples              # gtk-3-examples for focal
 [...]
-</pre>
-	    </dd>
-		<dd>Start one of the graphical application from the x11-apps package, like xcalc for example:
-<pre>
+```
+
+Start one of the graphical application from the x11-apps package, like xcalc for example:
+
+```
 $ xcalc
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the default backend:
-<pre>
+Start the GTK demo application with the default backend:
+
+```
 $ gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the Wayland backend:
-<pre>
+Start the GTK demo application with the Wayland backend:
+
+```
 $ GDK_BACKEND=wayland gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-	<dt>Check that Windows interoperability is still working
-	</dt>
-		<dd> Launch a Windows application
-<pre>
+**Check that Windows interoperability is still working**
+
+Launch a Windows application:
+
+```
 > notepad.exe # It should open.
-</pre>
-		</dd>
-		<dd> List the contents of the C:\Windows
-<pre>
+```
+
+List the contents of the `C:\Windows`:
+
+```
 > ls -l /mnt/c/Windows
 dr-xr-xr-x 1 root root     512 Feb 11 08:58  AppReadiness
 dr-xr-xr-x 1 root root     512 Apr  1  2024  Boot
@@ -246,42 +237,39 @@ dr-xr-xr-x 1 root root     512 Apr  1  2024  Branding
 dr-xr-xr-x 1 root root     512 Oct  7 14:37  BrowserCore
 dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 [...]
-</pre>
-		</dd>
+```
 
-<dt>Exit WSL
-    </dt>
-    <dd>
-<pre>logout</pre>
-    </dd>
-	<dd>Check that your back to the PowerShell prompt</dd>
+**Exit WSL**
 
-	<dt>Unregister the distro instance
-	    </dt>
-	    <dd>
-<pre>
+```
+logout
+```
+
+Check that your back to the PowerShell prompt.
+
+**Unregister the distro instance**
+
+```
 > wsl.exe --unregister Ubuntu20.04.3
-</pre>
-	    </dd>
-		<dd>The application	is no longer listed
-<pre>
+```
+
+The application is no longer listed:
+
+```
 > wsl --list
 Windows Subsystem for Linux Distributions:
 Ubuntu (Default)
 Ubuntu-Preview
 Ubuntu-20.04
 TestUbuntuWSL
-</pre>
-		</dd>
+```
 
-		<dd>And the directory is either missing or empty.
-<pre>
-&gt; ls .\wsl
-&gt;
-</pre>
-		</dd>
-</dl>
+And the directory is either missing or empty:
 
-<strong>If all actions produce the expected results listed, please <a href="results#add_result">submit</a> a 'passed' result.
-    If an action fails, or produces an unexpected result, please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include the bug number when you <a href="results#add_result">submit</a> your result.</strong>
+```
+> ls .\wsl
+>
+```
 
+**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
+If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**

--- a/resolute/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -230,7 +230,7 @@ $ sudo apt install x11-apps gtk-4-examples              # gtk-3-examples for foc
 [...]
 ```
 
-Start one of the graphical application from the x11-apps package, like xcalc for example:
+Start one of the graphical applications from the x11-apps package, like xcalc for example:
 
 ```
 $ xcalc

--- a/resolute/testsuites/WSL/Mandatory/WSL cloud-init.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL cloud-init.md
@@ -1,6 +1,6 @@
 This case tests provisioning tar-based WSL image with relevant cloud-config user data.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/resolute/testsuites/WSL/Mandatory/WSL cloud-init.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL cloud-init.md
@@ -40,7 +40,11 @@ write_files:
     [user]
     default=ubuntu
 
-packages: [hello, x11-apps, gtk-4-examples]
+packages:
+  - x11-apps
+  - gtk-4-examples
+  - snap:
+    - hello
 ```
 
 **Install a new instance from the image you downloaded**
@@ -154,12 +158,14 @@ Verify that the command ends successfully and that any package that must be upgr
 
 **CLI and graphical applications installed by cloud-init**
 
-Verify that the "hello" package has been successfully installed and the application can run:
+Verify that the "hello" package has been successfully installed and the application can run
+(If `/snap/bin` is not automatically added to your `PATH` then run `source /etc/profile`):
 
 ```
 $ hello
 Hello, world!
 ```
+
 
 Start one of the graphical application from the x11-apps package, like xcalc for example:
 
@@ -188,6 +194,24 @@ It's possible that it fails due [this WSL bug](https://github.com/microsoft/WSL/
 $ GDK_BACKEND=wayland XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir gtk4-demo
 (Wait a moment until the application starts and is displayed)
 ```
+
+**Install a snap package manually**
+
+Try a graphical snap such as `gnome-system-monitor`:
+
+```
+sudo snap install gnome-system-monitor
+gnome-system-monitor
+gnome-system-monitor
+libpxbackend-1.0.so: cannot open shared object file: No such file or directory
+Failed to load module: /home/user/snap/gnome-system-monitor/common/.cache/gio-modules/libgiolibproxy.so
+
+(gnome-system-monitor:6963): Gtk-WARNING **: 16:02:47.323: Trying to measure GtkButton 0x5757299c71e0 for width of 80, but it needs at least 88
+
+(gnome-system-monitor:6963): Gtk-CRITICAL **: 16:02:47.324: Allocation width too small. Tried to allocate 80x31, but GtkButton 0x5757299c71e0 needs at least 88x31.
+```
+
+_Some warnings may show up, the exact ones may depend on the application and version, but the window should render correctly and be functional_.
 
 **Check that Windows interoperability is still working**
 
@@ -238,4 +262,3 @@ TestUbuntuWSL
 **If all actions produce the expected results listed, please submit a `passed` result.** 
 
 **If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**
-

--- a/resolute/testsuites/WSL/Mandatory/WSL cloud-init.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL cloud-init.md
@@ -1,6 +1,6 @@
 This case tests provisioning tar-based WSL image with relevant cloud-config user data.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.5.7 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/resolute/testsuites/WSL/Mandatory/WSL cloud-init.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL cloud-init.md
@@ -1,30 +1,29 @@
-<p>This case tests provisioning tar-based WSL image with relevant cloud-config user data.</p>
+This case tests provisioning tar-based WSL image with relevant cloud-config user data.
 
 It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
 
-Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at <a href="https://cdimages.ubuntu.com/ubuntu-wsl/">https://cdimages.ubuntu.com/ubuntu-wsl/</a>
+Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".
 
-For example for latest noble image:  <a href="https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl">https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/noble/pending/noble-wsl-amd64.wsl</a>
+For example for latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
 Make sure to download the image matching the correct release under test from the download link associated to this test case.
 
 Those images have cloud-init seeded. To make sure your environment doesn't contain any files that could
 cause cloud-init to change the expected results of this test cases, empty the following directories on the
 host (Windows) filesystem (if they exist):
 
-<ul>
-	<li>%USERPROFILE%\.cloud-init</li>
-	<li>%USERPROFILE%\.ubuntupro\cloud-init</li>
-</ul>
+- `%USERPROFILE%\.cloud-init`
+- `%USERPROFILE%\.ubuntupro\cloud-init`
 
 After downloading the image, open PowerShell and execute the test case below:
 
-<dl>
-	<dt>Prepare the user data file</dt>
-	<dd>Open a text editor of your choice, create a new file with the following contents and save it as
-		<code>%USERPROFILE%\.cloud-init\Ubuntu-24.04.user-data</code> (adjust the filename to match the
-		release version under test, here assumed to be noble):
-<pre>
+**Prepare the user data file**
+
+Open a text editor of your choice, create a new file with the following contents and save it as
+`%USERPROFILE%\.cloud-init\Ubuntu-24.04.user-data` (adjust the filename to match the
+release version under test, here assumed to be noble):
+
+```
 #cloud-config
 locale: en_GB
 users:
@@ -42,33 +41,37 @@ write_files:
     default=ubuntu
 
 packages: [hello, x11-apps, gtk-4-examples]
-</pre>
-	</dd>
-	<dt>Install a new instance from the image you downloaded
-	    </dt>
-	    <dd>
-<pre>
+```
+
+**Install a new instance from the image you downloaded**
+
+```
 > wsl.exe --install --from-file .\noble-wsl-amd64.wsl
-</pre>
-	    </dd>
-		<dd>Verify that the new instance has been registered by running the following command:
-<pre>
+```
+
+Verify that the new instance has been registered by running the following command:
+
+```
 > wsl.exe --list --all --verbose
 NAME             STATE           VERSION
 *Ubuntu          Running         2
 Ubuntu-24.04     Stopped         2
 Ubuntu-20.04     Stopped         2
 TestUbuntuWSL    Stopped         2
-</pre></dd>
+```
 
-	<dt>Launch the new instance.</dt>
-	<dd>On the Windows Start Menu open the Windows Terminal. When open, at the top, at the right side of
-		the new tab button, click on the dropdown and select the "Ubuntu-24.04" profile. A new tab
-		will appear.</dd>
-	<dd>The provisioning (OOBE) command will run and eventually will run a shell
-		with the user described in the user data file logged in.</dd>
-		<dd>In the example below the Windows user name is ubuntu
-<pre>
+**Launch the new instance.**
+
+On the Windows Start Menu open the Windows Terminal. When open, at the top, at the right side of
+the new tab button, click on the dropdown and select the "Ubuntu-24.04" profile. A new tab
+will appear.
+
+The provisioning (OOBE) command will run and eventually will run a shell
+with the user described in the user data file logged in.
+
+In the example below the Windows user name is ubuntu:
+
+```
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 To run a command as administrator (user "root"), use "sudo <command>".
@@ -90,86 +93,113 @@ Welcome to Ubuntu 24.04.2 LTS (GNU/Linux 5.15.167.4-microsoft-standard-WSL2 x86_
 This message is shown once a day. To disable it please create the
 /home/ubuntu/.hushlogin file.
 ubuntu@mib01:/mnt/c/Users/ubuntu$
-</pre></dd>
-		<dd>Read through the entire message of the day. Make sure there is no warnings nor errors coming from
-			cloud-init</dd>
-		<dd>Verify that the background and foreground colors match the Ubuntu colors and the terminal
-		icon is the Ubuntu logo.</dd>
-		<dd>Verify that the text is rendered with the Ubuntu font.</dd>
-		<dd>Verify that	you're running the right distribution (point) release. For example run:
-<pre>
+```
+
+Read through the entire message of the day. Make sure there is no warnings nor errors coming from
+cloud-init.
+
+Verify that the background and foreground colors match the Ubuntu colors and the terminal
+icon is the Ubuntu logo.
+
+Verify that the text is rendered with the Ubuntu font.
+
+Verify that you're running the right distribution (point) release. For example run:
+
+```
 $ lsb_release -a
 No LSB modules are available.
 Distributor ID: Ubuntu
 Description:    Ubuntu 24.04.2 LTS
 Release:        24.04
 Codename:       noble
-</pre> </dd>
+```
 
-	<dt>Check systemd status</dt>
-		<dd>Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
-<pre>
+**Check systemd status**
+
+Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
+
+```
 $ systemctl is-system-running
 running
 $ systemctl --failed
   UNIT LOAD ACTIVE SUB DESCRIPTION
 
   0 loaded units listed.
-</pre></dd>
+```
 
-	<dt>The default user</dt>
-		<dd>You should be logged in with the user that you just created
-<pre>
+**The default user**
+
+You should be logged in with the user that you just created:
+
+```
 $ whoami
 ubuntu
-</pre></dd>
-		<dd>Run a command as root with sudo, for instance
-<pre>$ sudo apt update</pre></dd>
-		<dd>Verify that the command ends successfully</dd>
-		<dd>Apply any update
-<pre>$ sudo apt full-upgrade</pre></dd>
-		<dd>Verify that the command ends successfully and that any packge that must be upgraded has been upgraded</dd>
+```
 
-	<dt>CLI and graphical applications installed by cloud-init</dt>
-		<dd>Verify that the "hello" package has been successfully installed and the application can run
-<pre>
+Run a command as root with sudo, for instance:
+
+```
+$ sudo apt update
+```
+
+Verify that the command ends successfully.
+
+Apply any update:
+
+```
+$ sudo apt full-upgrade
+```
+
+Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
+
+**CLI and graphical applications installed by cloud-init**
+
+Verify that the "hello" package has been successfully installed and the application can run:
+
+```
 $ hello
 Hello, world!
-</pre></dd>
-		<dd>Start one of the graphical application from the x11-apps package, like xcalc for example:
-<pre>
+```
+
+Start one of the graphical application from the x11-apps package, like xcalc for example:
+
+```
 $ xcalc
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the default backend:
-<pre>
+Start the GTK demo application with the default backend:
+
+```
 $ gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the Wayland backend:
-<pre>
+Start the GTK demo application with the Wayland backend:
+
+```
 $ GDK_BACKEND=wayland gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre>
-		It's possible that it fails due <a href="https://github.com/microsoft/WSL/issues/11261">this
-			WSL bug</a>. To confirm that try again with a different XDG_RUNTIME_DIR as below:
-<pre>
+```
+
+It's possible that it fails due [this WSL bug](https://github.com/microsoft/WSL/issues/11261). To confirm that try again with a different XDG_RUNTIME_DIR as below:
+
+```
 $ GDK_BACKEND=wayland XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre>
-		</dd>
+```
 
-	<dt>Check that Windows interoperability is still working
-	</dt>
-		<dd> Launch a Windows application
-<pre>
+**Check that Windows interoperability is still working**
+
+Launch a Windows application:
+
+```
 > notepad.exe # It should open.
-</pre>
-		</dd>
-		<dd> List the contents of the C:\Windows
-<pre>
+```
+
+List the contents of the `C:\Windows`:
+
+```
 > ls -l /mnt/c/Windows
 dr-xr-xr-x 1 root root     512 Feb 11 08:58  AppReadiness
 dr-xr-xr-x 1 root root     512 Apr  1  2024  Boot
@@ -177,35 +207,31 @@ dr-xr-xr-x 1 root root     512 Apr  1  2024  Branding
 dr-xr-xr-x 1 root root     512 Oct  7 14:37  BrowserCore
 dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 [...]
-</pre>
-		</dd>
+```
 
-	<dt>Exit WSL
-	    </dt>
-	    <dd>
-<pre>logout</pre>
-	    </dd>
-		<dd>Check that your back to the PowerShell prompt</dd>
+**Exit WSL**
 
-	<dt>Unregister the distro instance
-	    </dt>
-	    <dd>
-<pre>
+```
+logout
+```
+
+Check that your back to the PowerShell prompt.
+
+**Unregister the distro instance**
+
+```
 > wsl.exe --unregister Ubuntu-24.04
-</pre>
-	    </dd>
-		<dd>The instance is no longer listed
-<pre>
+```
+
+The instance is no longer listed:
+
+```
 > wsl --list
 Windows Subsystem for Linux Distributions:
 Ubuntu (Default)
 Ubuntu-20.04
 TestUbuntuWSL
-</pre></dd>
+```
 
-</dl>
-
-<strong>If all actions produce the expected results listed, please <a href="results#add_result">submit</a> a 'passed' result.
-    If an action fails, or produces an unexpected result, please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include the bug number when you <a href="results#add_result">submit</a> your result.</strong>
-
-
+**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
+If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**

--- a/resolute/testsuites/WSL/Mandatory/WSL cloud-init.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL cloud-init.md
@@ -167,7 +167,7 @@ Hello, world!
 ```
 
 
-Start one of the graphical application from the x11-apps package, like xcalc for example:
+Start one of the graphical applications from the x11-apps package, like xcalc for example:
 
 ```
 $ xcalc

--- a/resolute/testsuites/WSL/Mandatory/WSL cloud-init.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL cloud-init.md
@@ -233,5 +233,9 @@ Ubuntu-20.04
 TestUbuntuWSL
 ```
 
-**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
-If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**
+---- 
+
+**If all actions produce the expected results listed, please submit a `passed` result.** 
+
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**
+

--- a/resolute/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
@@ -1,6 +1,6 @@
 This case tests provisioning a tar-based WSL image as WSL 1.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.5.7 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/resolute/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
@@ -115,7 +115,7 @@ $ sudo apt full-upgrade
 
 Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
 
-Install a package:
+**Install a package:**
 
 ```
 $ sudo apt install hello

--- a/resolute/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
@@ -1,6 +1,6 @@
 This case tests provisioning a tar-based WSL image as WSL 1.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/resolute/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
@@ -1,11 +1,11 @@
-<p>This case tests provisioning a tar-based WSL image as WSL 1.</p>
+This case tests provisioning a tar-based WSL image as WSL 1.
 
 It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
 
-Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at <a href="https://cdimages.ubuntu.com/ubuntu-wsl/">https://cdimages.ubuntu.com/ubuntu-wsl/</a>
+Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".
 
-For example for latest noble image:  <a href="https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl">https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/noble/pending/noble-wsl-amd64.wsl</a>
+For example for latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
 Make sure to download the image matching the correct release under test from the download link associated to this test case.
 
 WSL 1 doesn't support systemd, thus we skip checking if its running, if there are failed units. We also assume
@@ -13,39 +13,45 @@ cloud-init cannot run under such environment.
 
 After downloading the image, open PowerShell and follow the steps below:
 
-<dl>
-	<dt>Install a new instance as WSL 1</dt>
-		<dd>Navigate to the folder where you downloaded the image into and enter the following
-				command, adjusting to the correct release name under test
-<pre>
-&gt; wsl --install --from-file .\noble-wsl-amd64.wsl --location .\Noble --name Noble --version 1
-</pre>
-		</dd>
-		<dd>Verify that the new instance has been registered as WSL 1 by running the following command:
-<pre>
+**Install a new instance as WSL 1**
+
+Navigate to the folder where you downloaded the image into and enter the following
+command, adjusting to the correct release name under test:
+
+```
+> wsl --install --from-file .\noble-wsl-amd64.wsl --location .\Noble --name Noble --version 1
+```
+
+Verify that the new instance has been registered as WSL 1 by running the following command:
+
+```
 > wsl.exe --list --all --verbose
 NAME             STATE           VERSION
 *Ubuntu          Running         2
 Noble            Stopped         1
 Ubuntu-20.04     Stopped         2
 TestUbuntuWSL    Stopped         2
-</pre>
-		</dd>
-		<dd>Check the **name** used in previous command appears in the list.</dd>
+```
 
-	<dt>Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
-		the new user creation. The input line should be prefilled with a user name derived from the
-		current Windows user name.</dt>
-		<dd>In the example below the Windows user name is ubuntu
-<pre>
+Check the **name** used in previous command appears in the list.
+
+**Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
+the new user creation. The input line should be prefilled with a user name derived from the
+current Windows user name.**
+
+In the example below the Windows user name is ubuntu:
+
+```
 > wsl -d Noble
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
-</pre></dd>
-	<dd>Hit enter and proceed with the default user creation. Once done you should be running bash inside
-	the distro instance
-<pre>
+```
+
+Hit enter and proceed with the default user creation. Once done you should be running bash inside
+the distro instance:
+
+```
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
@@ -71,47 +77,68 @@ Welcome to Ubuntu 24.04.2 LTS (GNU/Linux 5.15.167.4-microsoft-standard-WSL2 x86_
 This message is shown once a day. To disable it please create the
 /home/ubuntu/.hushlogin file.
 ubuntu@mib01:/mnt/c/Users/ubuntu$
-</pre></dd>
+```
 
-		<dd>Verify that	you're running the right distribution (point) release. For example run:
-<pre>
+Verify that you're running the right distribution (point) release. For example run:
+
+```
 $ lsb_release -a
 No LSB modules are available.
 Distributor ID: Ubuntu
 Description:    Ubuntu 24.04.2 LTS
 Release:        24.04
 Codename:       noble
-</pre> </dd>
+```
 
-	<dt>The default user</dt>
-		<dd>You should be logged in with the user that you just created
-<pre>
+**The default user**
+
+You should be logged in with the user that you just created:
+
+```
 $ whoami
 ubuntu
-</pre></dd>
-		<dd>Run a command as root with sudo, for instance
-<pre>$ sudo apt update</pre></dd>
-		<dd>Verify that the command ends successfully</dd>
-		<dd>Apply any update
-<pre>$ sudo apt full-upgrade</pre></dd>
-		<dd>Verify that the command ends successfully and that any packge that must be upgraded has been upgraded</dd>
-		<dd>Install a package
-<pre>$ sudo apt install hello</pre></dd>
-		<dd>Verify that the package has been successfully installed and the application can run
-<pre>
+```
+
+Run a command as root with sudo, for instance:
+
+```
+$ sudo apt update
+```
+
+Verify that the command ends successfully.
+
+Apply any update:
+
+```
+$ sudo apt full-upgrade
+```
+
+Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
+
+Install a package:
+
+```
+$ sudo apt install hello
+```
+
+Verify that the package has been successfully installed and the application can run:
+
+```
 $ hello
 Hello, world!
-</pre></dd>
+```
 
-	<dt>Check that Windows interoperability is still working
-	</dt>
-		<dd> Launch a Windows application
-<pre>
+**Check that Windows interoperability is still working**
+
+Launch a Windows application:
+
+```
 > notepad.exe # It should open.
-</pre>
-		</dd>
-		<dd> List the contents of the C:\Windows
-<pre>
+```
+
+List the contents of the `C:\Windows`:
+
+```
 > ls -l /mnt/c/Windows
 dr-xr-xr-x 1 root root     512 Feb 11 08:58  AppReadiness
 dr-xr-xr-x 1 root root     512 Apr  1  2024  Boot
@@ -119,35 +146,31 @@ dr-xr-xr-x 1 root root     512 Apr  1  2024  Branding
 dr-xr-xr-x 1 root root     512 Oct  7 14:37  BrowserCore
 dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 [...]
-</pre>
-		</dd>
+```
 
-	<dt>Exit WSL
-	    </dt>
-	    <dd>
-<pre>logout</pre>
-	    </dd>
-		<dd>Check that your back to the PowerShell prompt</dd>
+**Exit WSL**
 
-	<dt>Unregister the distro instance
-	    </dt>
-	    <dd>
-<pre>
+```
+logout
+```
+
+Check that your back to the PowerShell prompt.
+
+**Unregister the distro instance**
+
+```
 > wsl.exe --unregister Noble
-</pre>
-	    </dd>
-		<dd>The isntance no longer listed
-<pre>
+```
+
+The instance no longer listed:
+
+```
 > wsl --list
 Windows Subsystem for Linux Distributions:
 Ubuntu (Default)
 Ubuntu-20.04
 TestUbuntuWSL
-</pre></dd>
+```
 
-</dl>
-
-<strong>If all actions produce the expected results listed, please <a href="results#add_result">submit</a> a 'passed' result.
-    If an action fails, or produces an unexpected result, please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include the bug number when you <a href="results#add_result">submit</a> your result.</strong>
-
-
+**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
+If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**

--- a/resolute/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
+++ b/resolute/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
@@ -172,5 +172,8 @@ Ubuntu-20.04
 TestUbuntuWSL
 ```
 
-**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
-If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**
+---- 
+
+**If all actions produce the expected results listed, please submit a `passed` result.** 
+
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/stonking/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/stonking/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -15,34 +15,14 @@ host (Windows) filesystem (if they exist):
 - `%USERPROFILE%\.cloud-init`
 - `%USERPROFILE%\.ubuntupro\cloud-init`
 
-After downloading the image, navigate to it on Windows explorer:
+**Double click to install:**
 
-**Double-click the image to start the installation**
+After downloading the image, navigate to it on Windows explorer and double-click the image file to start the installation.
 
 A new terminal window will pop-up showing the registration progress. In the end it will
-give instructions to start a new shell into the new instance. Take note of that command. For
-example (for noble):
-
-```
-> wsl.exe -d Ubuntu-24.04
-```
-
-Verify that the new instance has been registered by running the following command:
-
-```
-> wsl.exe --list --all --verbose
-NAME             STATE           VERSION
-*Ubuntu          Running         2
-Ubuntu-24.04     Stopped         2
-Ubuntu-20.04     Stopped         2
-TestUbuntuWSL    Stopped         2
-```
-
-Check the the name used in previous command appears in the list.
-
-**Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
-the new user creation. The input line should be prefilled with a user name derived from the
-current Windows user name.**
+run the first boot experience, the provisioning (OOBE) command, and eventually will prompt for
+the new user creation. **The input line should be prefilled with a user name derived from the
+current Windows user name**, but that's a suggestion, users are free to change it and hit enter.
 
 In the example below the Windows user name is ubuntu:
 

--- a/stonking/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/stonking/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -225,5 +225,8 @@ Ubuntu-20.04
 TestUbuntuWSL
 ```
 
-**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
-If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**
+---- 
+
+**If all actions produce the expected results listed, please submit a `passed` result.** 
+
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/stonking/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/stonking/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -1,6 +1,6 @@
 This case tests the implicit provisioning (double-click install) of a tar-based WSL image.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.5.7 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/stonking/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/stonking/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -119,10 +119,43 @@ Verify that the command ends successfully and that any package that must be upgr
 $ sudo apt install hello
 ```
 
-Verify that the package has been successfully installed and the application can run:
+Verify that the package has been successfully installed and the application can run
+(If `/snap/bin` is not automatically added to your `PATH` then run `source /etc/profile`): 
 
 ```
 $ hello
+Hello, world!
+```
+
+**Install a snap package**
+
+```
+$ sudo apt remove hello
+```
+
+Verify that the package has been successfully uninstalled and the application can run:
+
+```
+$ hello
+Command 'hello' not found, but can be installed with:
+sudo snap install hello  # version 2.10, or
+sudo apt  install hello  # version 2.10-5build1
+See 'snap info hello' for additional versions.
+```
+
+Then install the snap version:
+
+```
+$ sudo snap install hello
+```
+
+Verify that the package has been successfully installed and the application can run
+(If `/snap/bin` is not automatically added to your `PATH` then run `source /etc/profile`): 
+
+```
+$ hello
+Hello, world!
+$ snap run hello
 Hello, world!
 ```
 
@@ -160,6 +193,22 @@ It's possible that it fails due [this WSL bug](https://github.com/microsoft/WSL/
 $ GDK_BACKEND=wayland XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir gtk4-demo
 (Wait a moment until the application starts and is displayed)
 ```
+
+Try a graphical snap as well:
+
+```
+sudo snap install gnome-system-monitor
+gnome-system-monitor
+gnome-system-monitor
+libpxbackend-1.0.so: cannot open shared object file: No such file or directory
+Failed to load module: /home/user/snap/gnome-system-monitor/common/.cache/gio-modules/libgiolibproxy.so
+
+(gnome-system-monitor:6963): Gtk-WARNING **: 16:02:47.323: Trying to measure GtkButton 0x5757299c71e0 for width of 80, but it needs at least 88
+
+(gnome-system-monitor:6963): Gtk-CRITICAL **: 16:02:47.324: Allocation width too small. Tried to allocate 80x31, but GtkButton 0x5757299c71e0 needs at least 88x31.
+```
+
+_Some warnings may show up, the exact ones may depend on the application and version, but the window should render correctly and be functional_.
 
 **Check that Windows interoperability is still working**
 

--- a/stonking/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/stonking/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -166,7 +166,7 @@ $ sudo apt install x11-apps gtk-4-examples libgles2
 [...]
 ```
 
-Start one of the graphical application from the x11-apps package, like xcalc for example:
+Start one of the graphical applications from the x11-apps package, like xcalc for example:
 
 ```
 $ xcalc

--- a/stonking/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/stonking/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -1,6 +1,6 @@
 This case tests the implicit provisioning (double-click install) of a tar-based WSL image.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/stonking/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/stonking/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -187,9 +187,11 @@ dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 logout
 ```
 
-Check that your back to the PowerShell prompt.
+The terminal window will close.
 
 **Unregister the distro instance**
+
+Run the following command on a new PowerShell tab:
 
 ```
 > wsl.exe --unregister Ubuntu-24.04

--- a/stonking/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/stonking/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -1,58 +1,62 @@
-<p>This case tests the implicit provisioning (double-click install) of a tar-based WSL image.</p>
+This case tests the implicit provisioning (double-click install) of a tar-based WSL image.
 
 It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
 
-Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at <a href="https://cdimages.ubuntu.com/ubuntu-wsl/">https://cdimages.ubuntu.com/ubuntu-wsl/</a>
+Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".
 
-For example for latest noble image:  <a href="https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl">https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/noble/pending/noble-wsl-amd64.wsl</a>
+For example for latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
 Make sure to download the image matching the correct release under test from the download link associated to this test case.
 
 Those images have cloud-init seeded. To make sure your environment doesn't contain any files that could
 cause cloud-init to change the expected results of this test cases, remove the following directories on the
 host (Windows) filesystem (if they exist):
 
-<ul>
-	<li>%USERPROFILE%\.cloud-init</li>
-	<li>%USERPROFILE%\.ubuntupro\cloud-init</li>
-</ul>
+- `%USERPROFILE%\.cloud-init`
+- `%USERPROFILE%\.ubuntupro\cloud-init`
 
 After downloading the image, navigate to it on Windows explorer:
 
-<dl>
-	<dt>Double-click the image to start the installation</dt>
-		<dd>A new terminal window will pop-up showing the registration progress. In the end it will
-		give instructions to start a new shell into the new instance. Take note of that command. For
-		example (for noble):
-<pre>
+**Double-click the image to start the installation**
+
+A new terminal window will pop-up showing the registration progress. In the end it will
+give instructions to start a new shell into the new instance. Take note of that command. For
+example (for noble):
+
+```
 > wsl.exe -d Ubuntu-24.04
-</pre>
-		</dd>
-		<dd>Verify that the new instance has been registered by running the following command:
-<pre>
+```
+
+Verify that the new instance has been registered by running the following command:
+
+```
 > wsl.exe --list --all --verbose
 NAME             STATE           VERSION
 *Ubuntu          Running         2
 Ubuntu-24.04     Stopped         2
 Ubuntu-20.04     Stopped         2
 TestUbuntuWSL    Stopped         2
-</pre>
-		</dd>
-		<dd>Check the the name used in previous command appears in the list.</dd>
+```
 
-	<dt>Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
-		the new user creation. The input line should be prefilled with a user name derived from the
-		current Windows user name.</dt>
-		<dd>In the example below the Windows user name is ubuntu
-<pre>
+Check the the name used in previous command appears in the list.
+
+**Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
+the new user creation. The input line should be prefilled with a user name derived from the
+current Windows user name.**
+
+In the example below the Windows user name is ubuntu:
+
+```
 > wsl -d Ubuntu-24.04
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
-</pre></dd>
-	<dd>Hit enter and proceed with the default user creation. Once done you should be running bash inside
-	the distro instance
-<pre>
+```
+
+Hit enter and proceed with the default user creation. Once done you should be running bash inside
+the distro instance:
+
+```
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
@@ -78,91 +82,116 @@ Welcome to Ubuntu 24.04.2 LTS (GNU/Linux 5.15.167.4-microsoft-standard-WSL2 x86_
 This message is shown once a day. To disable it please create the
 /home/ubuntu/.hushlogin file.
 ubuntu@mib01:/mnt/c/Users/ubuntu$
-</pre></dd>
+```
 
-		<dd>Verify that	you're running the right distribution (point) release. For example run:
-<pre>
+Verify that you're running the right distribution (point) release. For example run:
+
+```
 $ lsb_release -a
 No LSB modules are available.
 Distributor ID: Ubuntu
 Description:    Ubuntu 24.04.2 LTS
 Release:        24.04
 Codename:       noble
-</pre> </dd>
+```
 
-	<dt>Check systemd status</dt>
-		<dd>Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
-<pre>
+**Check systemd status**
+
+Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
+
+```
 $ systemctl is-system-running
 running
 $ systemctl --failed
   UNIT LOAD ACTIVE SUB DESCRIPTION
 
   0 loaded units listed.
-</pre></dd>
+```
 
-	<dt>The default user</dt>
-		<dd>You should be logged in with the user that you just created
-<pre>
+**The default user**
+
+You should be logged in with the user that you just created:
+
+```
 $ whoami
 ubuntu
-</pre></dd>
-		<dd>Run a command as root with sudo, for instance
-<pre>$ sudo apt update</pre></dd>
-		<dd>Verify that the command ends successfully</dd>
-		<dd>Apply any update
-<pre>$ sudo apt full-upgrade</pre></dd>
-		<dd>Verify that the command ends successfully and that any packge that must be upgraded has been upgraded</dd>
-		<dd>Install a package
-<pre>$ sudo apt install hello</pre></dd>
-		<dd>Verify that the package has been successfully installed and the application can run
-<pre>
+```
+
+Run a command as root with sudo, for instance:
+
+```
+$ sudo apt update
+```
+
+Verify that the command ends successfully.
+
+Apply any update:
+
+```
+$ sudo apt full-upgrade
+```
+
+Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
+
+Install a package:
+
+```
+$ sudo apt install hello
+```
+
+Verify that the package has been successfully installed and the application can run:
+
+```
 $ hello
 Hello, world!
-</pre></dd>
+```
 
-	<dt>Install and run graphical applications
-	    </dt>
-	    <dd>
-<pre>
+**Install and run graphical applications**
+
+```
 $ sudo apt install x11-apps gtk-4-examples libgles2
 [...]
-</pre>
-	    </dd>
-		<dd>Start one of the graphical application from the x11-apps package, like xcalc for example:
-<pre>
+```
+
+Start one of the graphical application from the x11-apps package, like xcalc for example:
+
+```
 $ xcalc
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the default backend:
-<pre>
+Start the GTK demo application with the default backend:
+
+```
 $ gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the Wayland backend:
-<pre>
+Start the GTK demo application with the Wayland backend:
+
+```
 $ GDK_BACKEND=wayland gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre>
-		It's possible that it fails due <a href="https://github.com/microsoft/WSL/issues/11261">this
-			WSL bug</a>. To confirm that try again with a different XDG_RUNTIME_DIR as below:
-<pre>
+```
+
+It's possible that it fails due [this WSL bug](https://github.com/microsoft/WSL/issues/11261). To confirm that try again with a different XDG_RUNTIME_DIR as below:
+
+```
 $ GDK_BACKEND=wayland XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre>
-		</dd>
+```
 
-	<dt>Check that Windows interoperability is still working
-	</dt>
-		<dd> Launch a Windows application
-<pre>
+**Check that Windows interoperability is still working**
+
+Launch a Windows application:
+
+```
 > notepad.exe # It should open.
-</pre>
-		</dd>
-		<dd> List the contents of the C:\Windows
-<pre>
+```
+
+List the contents of the `C:\Windows`:
+
+```
 > ls -l /mnt/c/Windows
 dr-xr-xr-x 1 root root     512 Feb 11 08:58  AppReadiness
 dr-xr-xr-x 1 root root     512 Apr  1  2024  Boot
@@ -170,37 +199,31 @@ dr-xr-xr-x 1 root root     512 Apr  1  2024  Branding
 dr-xr-xr-x 1 root root     512 Oct  7 14:37  BrowserCore
 dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 [...]
-</pre>
-		</dd>
+```
 
-	<dt>Exit WSL
-	    </dt>
-	    <dd>
-<pre>logout</pre>
-	    </dd>
-		<dd>Check that your back to the PowerShell prompt</dd>
+**Exit WSL**
 
-	<dt>Unregister the distro instance
-	    </dt>
-	    <dd>
-<pre>
+```
+logout
+```
+
+Check that your back to the PowerShell prompt.
+
+**Unregister the distro instance**
+
+```
 > wsl.exe --unregister Ubuntu-24.04
-</pre>
-	    </dd>
-		<dd>The isntance no longer listed
-<pre>
+```
+
+The instance no longer listed:
+
+```
 > wsl --list
 Windows Subsystem for Linux Distributions:
 Ubuntu (Default)
 Ubuntu-20.04
 TestUbuntuWSL
-</pre></dd>
+```
 
-</dl>
-
-<strong>If all actions produce the expected results listed, please <a href="results#add_result">submit</a> a 'passed' result.
-    If an action fails, or produces an unexpected result, please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include the bug number when you <a href="results#add_result">submit</a> your result.</strong>
-
-
-
-
+**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
+If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**

--- a/stonking/testsuites/WSL/Disabled/WSL_Double Click.md
+++ b/stonking/testsuites/WSL/Disabled/WSL_Double Click.md
@@ -113,7 +113,7 @@ $ sudo apt full-upgrade
 
 Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
 
-Install a package:
+**Install a package:**
 
 ```
 $ sudo apt install hello

--- a/stonking/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -186,9 +186,11 @@ dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 logout
 ```
 
-Check that your back to the PowerShell prompt.
+The terminal window will close.
 
 **Unregister the distro instance**
+
+Run the following command on a new PowerShell tab:
 
 ```
 > wsl.exe --unregister Ubuntu-24.04

--- a/stonking/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -1,58 +1,62 @@
-<p>This case tests the implicit provisioning (double-click install) of a tar-based WSL image.</p>
+This case tests the implicit provisioning (double-click install) of a tar-based WSL image.
 
 It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
 
-Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at <a href="https://cdimages.ubuntu.com/ubuntu-wsl/">https://cdimages.ubuntu.com/ubuntu-wsl/</a>
+Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".
 
-For example for latest noble image:  <a href="https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl">https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/noble/pending/noble-wsl-amd64.wsl</a>
+For example for latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
 Make sure to download the image matching the correct release under test from the download link associated to this test case.
 
 Those images have cloud-init seeded. To make sure your environment doesn't contain any files that could
 cause cloud-init to change the expected results of this test cases, remove the following directories on the
 host (Windows) filesystem (if they exist):
 
-<ul>
-	<li>%USERPROFILE%\.cloud-init</li>
-	<li>%USERPROFILE%\.ubuntupro\cloud-init</li>
-</ul>
+- `%USERPROFILE%\.cloud-init`
+- `%USERPROFILE%\.ubuntupro\cloud-init`
 
 After downloading the image, navigate to it on Windows explorer:
 
-<dl>
-	<dt>Double-click the image to start the installation</dt>
-		<dd>A new terminal window will pop-up showing the registration progress. In the end it will
-		give instructions to start a new shell into the new instance. Take note of that command. For
-		example (for noble):
-<pre>
+**Double-click the image to start the installation**
+
+A new terminal window will pop-up showing the registration progress. In the end it will
+give instructions to start a new shell into the new instance. Take note of that command. For
+example (for noble):
+
+```
 > wsl.exe -d Ubuntu-24.04
-</pre>
-		</dd>
-		<dd>Verify that the new instance has been registered by running the following command:
-<pre>
+```
+
+Verify that the new instance has been registered by running the following command:
+
+```
 > wsl.exe --list --all --verbose
 NAME             STATE           VERSION
 *Ubuntu          Running         2
 Ubuntu-24.04     Stopped         2
 Ubuntu-20.04     Stopped         2
 TestUbuntuWSL    Stopped         2
-</pre>
-		</dd>
-		<dd>Check the the name used in previous command appears in the list.</dd>
+```
 
-	<dt>Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
-		the new user creation. The input line should be prefilled with a user name derived from the
-		current Windows user name.</dt>
-		<dd>In the example below the Windows user name is ubuntu
-<pre>
+Check the the name used in previous command appears in the list.
+
+**Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
+the new user creation. The input line should be prefilled with a user name derived from the
+current Windows user name.**
+
+In the example below the Windows user name is ubuntu:
+
+```
 > wsl -d Ubuntu-24.04
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
-</pre></dd>
-	<dd>Hit enter and proceed with the default user creation. Once done you should be running bash inside
-	the distro instance
-<pre>
+```
+
+Hit enter and proceed with the default user creation. Once done you should be running bash inside
+the distro instance:
+
+```
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
@@ -78,91 +82,116 @@ Welcome to Ubuntu 24.04.2 LTS (GNU/Linux 5.15.167.4-microsoft-standard-WSL2 x86_
 This message is shown once a day. To disable it please create the
 /home/ubuntu/.hushlogin file.
 ubuntu@mib01:/mnt/c/Users/ubuntu$
-</pre></dd>
+```
 
-		<dd>Verify that	you're running the right distribution (point) release. For example run:
-<pre>
+Verify that you're running the right distribution (point) release. For example run:
+
+```
 $ lsb_release -a
 No LSB modules are available.
 Distributor ID: Ubuntu
 Description:    Ubuntu 24.04.2 LTS
 Release:        24.04
 Codename:       noble
-</pre> </dd>
+```
 
-	<dt>Check systemd status</dt>
-		<dd>Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
-<pre>
+**Check systemd status**
+
+Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
+
+```
 $ systemctl is-system-running
 running
 $ systemctl --failed
   UNIT LOAD ACTIVE SUB DESCRIPTION
 
   0 loaded units listed.
-</pre></dd>
+```
 
-	<dt>The default user</dt>
-		<dd>You should be logged in with the user that you just created
-<pre>
+**The default user**
+
+You should be logged in with the user that you just created:
+
+```
 $ whoami
 ubuntu
-</pre></dd>
-		<dd>Run a command as root with sudo, for instance
-<pre>$ sudo apt update</pre></dd>
-		<dd>Verify that the command ends successfully</dd>
-		<dd>Apply any update
-<pre>$ sudo apt full-upgrade</pre></dd>
-		<dd>Verify that the command ends successfully and that any packge that must be upgraded has been upgraded</dd>
-		<dd>Install a package
-<pre>$ sudo apt install hello</pre></dd>
-		<dd>Verify that the package has been successfully installed and the application can run
-<pre>
+```
+
+Run a command as root with sudo, for instance:
+
+```
+$ sudo apt update
+```
+
+Verify that the command ends successfully.
+
+Apply any update:
+
+```
+$ sudo apt full-upgrade
+```
+
+Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
+
+Install a package:
+
+```
+$ sudo apt install hello
+```
+
+Verify that the package has been successfully installed and the application can run:
+
+```
 $ hello
 Hello, world!
-</pre></dd>
+```
 
-	<dt>Install and run graphical applications
-	    </dt>
-	    <dd>
-<pre>
+**Install and run graphical applications**
+
+```
 $ sudo apt install x11-apps gtk-4-examples
 [...]
-</pre>
-	    </dd>
-		<dd>Start one of the graphical application from the x11-apps package, like xcalc for example:
-<pre>
+```
+
+Start one of the graphical application from the x11-apps package, like xcalc for example:
+
+```
 $ xcalc
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the default backend:
-<pre>
+Start the GTK demo application with the default backend:
+
+```
 $ gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the Wayland backend:
-<pre>
+Start the GTK demo application with the Wayland backend:
+
+```
 $ GDK_BACKEND=wayland gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre>
-		It's possible that it fails due <a href="https://github.com/microsoft/WSL/issues/11261">this
-			WSL bug</a>. To confirm that try again with a different XDG_RUNTIME_DIR as below:
-<pre>
+```
+
+It's possible that it fails due [this WSL bug](https://github.com/microsoft/WSL/issues/11261). To confirm that try again with a different XDG_RUNTIME_DIR as below:
+
+```
 $ GDK_BACKEND=wayland XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre>
-		</dd>
+```
 
-	<dt>Check that Windows interoperability is still working
-	</dt>
-		<dd> Launch a Windows application
-<pre>
+**Check that Windows interoperability is still working**
+
+Launch a Windows application:
+
+```
 > notepad.exe # It should open.
-</pre>
-		</dd>
-		<dd> List the contents of the C:\Windows
-<pre>
+```
+
+List the contents of the `C:\Windows`:
+
+```
 > ls -l /mnt/c/Windows
 dr-xr-xr-x 1 root root     512 Feb 11 08:58  AppReadiness
 dr-xr-xr-x 1 root root     512 Apr  1  2024  Boot
@@ -170,35 +199,31 @@ dr-xr-xr-x 1 root root     512 Apr  1  2024  Branding
 dr-xr-xr-x 1 root root     512 Oct  7 14:37  BrowserCore
 dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 [...]
-</pre>
-		</dd>
+```
 
-	<dt>Exit WSL
-	    </dt>
-	    <dd>
-<pre>logout</pre>
-	    </dd>
-		<dd>Check that your back to the PowerShell prompt</dd>
+**Exit WSL**
 
-	<dt>Unregister the distro instance
-	    </dt>
-	    <dd>
-<pre>
+```
+logout
+```
+
+Check that your back to the PowerShell prompt.
+
+**Unregister the distro instance**
+
+```
 > wsl.exe --unregister Ubuntu-24.04
-</pre>
-	    </dd>
-		<dd>The isntance no longer listed
-<pre>
+```
+
+The instance no longer listed:
+
+```
 > wsl --list
 Windows Subsystem for Linux Distributions:
 Ubuntu (Default)
 Ubuntu-20.04
 TestUbuntuWSL
-</pre></dd>
+```
 
-</dl>
-
-<strong>If all actions produce the expected results listed, please <a href="results#add_result">submit</a> a 'passed' result.
-    If an action fails, or produces an unexpected result, please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include the bug number when you <a href="results#add_result">submit</a> your result.</strong>
-
-
+**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
+If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**

--- a/stonking/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -225,5 +225,8 @@ Ubuntu-20.04
 TestUbuntuWSL
 ```
 
-**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
-If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**
+---- 
+
+**If all actions produce the expected results listed, please submit a `passed` result.** 
+
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/stonking/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -164,7 +164,7 @@ $ sudo apt install x11-apps gtk-4-examples
 [...]
 ```
 
-Start one of the graphical application from the x11-apps package, like xcalc for example:
+Start one of the graphical applications from the x11-apps package, like xcalc for example:
 
 ```
 $ xcalc

--- a/stonking/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -1,6 +1,6 @@
 This case tests the implicit provisioning (double-click install) of a tar-based WSL image.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.5.7 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/stonking/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -15,39 +15,18 @@ host (Windows) filesystem (if they exist):
 - `%USERPROFILE%\.cloud-init`
 - `%USERPROFILE%\.ubuntupro\cloud-init`
 
-After downloading the image, navigate to it on Windows explorer:
+**Double click to install:**
 
-**Double-click the image to start the installation**
+After downloading the image, navigate to it on Windows explorer and double-click the image file to start the installation.
 
 A new terminal window will pop-up showing the registration progress. In the end it will
-give instructions to start a new shell into the new instance. Take note of that command. For
-example (for noble):
-
-```
-> wsl.exe -d Ubuntu-24.04
-```
-
-Verify that the new instance has been registered by running the following command:
-
-```
-> wsl.exe --list --all --verbose
-NAME             STATE           VERSION
-*Ubuntu          Running         2
-Ubuntu-24.04     Stopped         2
-Ubuntu-20.04     Stopped         2
-TestUbuntuWSL    Stopped         2
-```
-
-Check the the name used in previous command appears in the list.
-
-**Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
-the new user creation. The input line should be prefilled with a user name derived from the
-current Windows user name.**
+run the first boot experience, the provisioning (OOBE) command, and eventually will prompt for
+the new user creation. **The input line should be prefilled with a user name derived from the
+current Windows user name**, but that's a suggestion, users are free to change it and hit enter.
 
 In the example below the Windows user name is ubuntu:
 
 ```
-> wsl -d Ubuntu-24.04
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu

--- a/stonking/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -15,7 +15,7 @@ host (Windows) filesystem (if they exist):
 - `%USERPROFILE%\.cloud-init`
 - `%USERPROFILE%\.ubuntupro\cloud-init`
 
-**Double click to install:**
+**Double click to install**
 
 After downloading the image, navigate to it on Windows explorer and double-click the image file to start the installation.
 
@@ -112,16 +112,48 @@ $ sudo apt full-upgrade
 
 Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
 
-**Install a package**:
+**Install a package**
 
 ```
 $ sudo apt install hello
 ```
 
-Verify that the package has been successfully installed and the application can run:
+Verify that the package has been successfully installed and the application can run: 
 
 ```
 $ hello
+Hello, world!
+```
+
+**Install a snap package**
+
+```
+$ sudo apt remove hello
+```
+
+Verify that the package has been successfully uninstalled and the application can run:
+
+```
+$ hello
+Command 'hello' not found, but can be installed with:
+sudo snap install hello  # version 2.10, or
+sudo apt  install hello  # version 2.10-5build1
+See 'snap info hello' for additional versions.
+```
+
+Then install the snap version:
+
+```
+$ sudo snap install hello
+```
+
+Verify that the package has been successfully installed and the application can run
+(If `/snap/bin` is not automatically added to your `PATH` then run `source /etc/profile`): 
+
+```
+$ hello
+Hello, world!
+$ snap run hello
 Hello, world!
 ```
 
@@ -159,6 +191,22 @@ It's possible that it fails due [this WSL bug](https://github.com/microsoft/WSL/
 $ GDK_BACKEND=wayland XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir gtk4-demo
 (Wait a moment until the application starts and is displayed)
 ```
+
+Try a graphical snap as well:
+
+```
+sudo snap install gnome-system-monitor
+gnome-system-monitor
+gnome-system-monitor
+libpxbackend-1.0.so: cannot open shared object file: No such file or directory
+Failed to load module: /home/user/snap/gnome-system-monitor/common/.cache/gio-modules/libgiolibproxy.so
+
+(gnome-system-monitor:6963): Gtk-WARNING **: 16:02:47.323: Trying to measure GtkButton 0x5757299c71e0 for width of 80, but it needs at least 88
+
+(gnome-system-monitor:6963): Gtk-CRITICAL **: 16:02:47.324: Allocation width too small. Tried to allocate 80x31, but GtkButton 0x5757299c71e0 needs at least 88x31.
+```
+
+_Some warnings may show up, the exact ones may depend on the application and version, but the window should render correctly and be functional_.
 
 **Check that Windows interoperability is still working**
 

--- a/stonking/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -1,6 +1,6 @@
 This case tests the implicit provisioning (double-click install) of a tar-based WSL image.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/stonking/testsuites/WSL/Mandatory/WSL Double Click.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL Double Click.md
@@ -112,7 +112,7 @@ $ sudo apt full-upgrade
 
 Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
 
-Install a package:
+**Install a package**:
 
 ```
 $ sudo apt install hello

--- a/stonking/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -2,14 +2,11 @@ This test case imports a WSL image from a rootfs and runs it.
 
 It requires a working Microsoft Windows 11 or higher installation with WSL version 2.5.7 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
-To run this test you must download the image from [http://cloud-images.ubuntu.com/](http://cloud-images.ubuntu.com/)
+Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
+and their file extension is ".wsl" instead of ".tar.gz".
 
-> Since the release of Ubuntu LTS 24.04.2 Noble Numbat, new images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
-> and their file extension is ".wsl" instead of ".tar.gz".
-
-For example for latest focal image download: [http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-wsl.rootfs.tar.gz](http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-wsl.rootfs.tar.gz)
-and for the latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
-Make sure to download the image from the download link associated to this test case.
+For example for latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
+Make sure to download the image matching the correct release under test from the download link associated to this test case.
 
 Latest releases have cloud-init seeded. To make sure your environment doesn't contain any files that could
 cause cloud-init to change the expected results of this test cases, remove the following directories on the

--- a/stonking/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -271,5 +271,8 @@ And the directory is either missing or empty:
 >
 ```
 
-**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
-If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**
+---- 
+
+**If all actions produce the expected results listed, please submit a `passed` result.** 
+
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**

--- a/stonking/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -1,6 +1,6 @@
 This test case imports a WSL image from a rootfs and runs it.
 
-It requires a working Microsoft Windows 10 or higher installation with WSL2 enabled. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.5.7 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 To run this test you must download the image from [http://cloud-images.ubuntu.com/](http://cloud-images.ubuntu.com/)
 

--- a/stonking/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -184,10 +184,42 @@ Verify that the command ends successfully and that any package that must be upgr
 $ sudo apt install hello
 ```
 
-Verify that the package has been successfully installed and the application can run:
+Verify that the package has been successfully installed and the application can run: 
 
 ```
 $ hello
+Hello, world!
+```
+
+**Install a snap package**
+
+```
+$ sudo apt remove hello
+```
+
+Verify that the package has been successfully uninstalled and the application can run:
+
+```
+$ hello
+Command 'hello' not found, but can be installed with:
+sudo snap install hello  # version 2.10, or
+sudo apt  install hello  # version 2.10-5build1
+See 'snap info hello' for additional versions.
+```
+
+Then install the snap version:
+
+```
+$ sudo snap install hello
+```
+
+Verify that the package has been successfully installed and the application can run
+(If `/snap/bin` is not automatically added to your `PATH` then run `source /etc/profile`): 
+
+```
+$ hello
+Hello, world!
+$ snap run hello
 Hello, world!
 ```
 
@@ -218,6 +250,22 @@ Start the GTK demo application with the Wayland backend:
 $ GDK_BACKEND=wayland gtk4-demo
 (Wait a moment until the application starts and is displayed)
 ```
+
+Try a graphical snap as well:
+
+```
+sudo snap install gnome-system-monitor
+gnome-system-monitor
+gnome-system-monitor
+libpxbackend-1.0.so: cannot open shared object file: No such file or directory
+Failed to load module: /home/user/snap/gnome-system-monitor/common/.cache/gio-modules/libgiolibproxy.so
+
+(gnome-system-monitor:6963): Gtk-WARNING **: 16:02:47.323: Trying to measure GtkButton 0x5757299c71e0 for width of 80, but it needs at least 88
+
+(gnome-system-monitor:6963): Gtk-CRITICAL **: 16:02:47.324: Allocation width too small. Tried to allocate 80x31, but GtkButton 0x5757299c71e0 needs at least 88x31.
+```
+
+_Some warnings may show up, the exact ones may depend on the application and version, but the window should render correctly and be functional_.
 
 **Check that Windows interoperability is still working**
 

--- a/stonking/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -60,8 +60,7 @@ Release:        20.04
 Codename:       focal
 ```
 
-**Since Jammy (22.04) systemd is also enabled by default, so make sure it's running and that there are no
-failed units:**
+Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
 
 ```
 $ systemctl is-system-running

--- a/stonking/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -1,46 +1,40 @@
-<p>This test case imports a WSL image from a rootfs and runs it.</p>
+This test case imports a WSL image from a rootfs and runs it.
 
 It requires a working Microsoft Windows 10 or higher installation with WSL2 enabled. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
 
-To run this test you must download the image from <a href="http://cloud-images.ubuntu.com/">http://cloud-images.ubuntu.com/</a>
+To run this test you must download the image from [http://cloud-images.ubuntu.com/](http://cloud-images.ubuntu.com/)
 
-<pre>
-Since the release of Ubuntu LTS 24.04.2 Noble Numbat, new images are found at <a href="https://cdimages.ubuntu.com/ubuntu-wsl/">https://cdimages.ubuntu.com/ubuntu-wsl/</a>
-and their file extension is ".wsl" instead of ".tar.gz".
-</pre>
+> Since the release of Ubuntu LTS 24.04.2 Noble Numbat, new images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
+> and their file extension is ".wsl" instead of ".tar.gz".
 
-For example for latest focal image download: <a
-	href="http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-wsl.rootfs.tar.gz">http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-wsl.rootfs.tar.gz</a>
-and for the latest noble image:  <a href="https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl">https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/noble/pending/noble-wsl-amd64.wsl</a>
+For example for latest focal image download: [http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-wsl.rootfs.tar.gz](http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-wsl.rootfs.tar.gz)
+and for the latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
 Make sure to download the image from the download link associated to this test case.
 
 Latest releases have cloud-init seeded. To make sure your environment doesn't contain any files that could
 cause cloud-init to change the expected results of this test cases, remove the following directories on the
 host (Windows) filesystem (if they exist):
 
-<ul>
-<li>%USERPROFILE%\.cloud-init</li>
-<li>%USERPROFILE%\.ubuntupro\cloud-init</li>
-</ul>
-
+- `%USERPROFILE%\.cloud-init`
+- `%USERPROFILE%\.ubuntupro\cloud-init`
 
 Open Windows Terminal or PowerShell and execute the test case below:
 
-<dl>
-	<dt>Import the image in WSL
-	    </dt>
-	    <dd>
-<pre>
-> wsl.exe --import &lt;name of the distro&gt; &lt;location to unpack rootfs&gt; &lt;rootfs&gt; [--version &lt;version of WSL&gt;]
-</pre>
-	    </dd>
-		<dd>For example:
-<pre>
+**Import the image in WSL**
+
+```
+> wsl.exe --import <name of the distro> <location to unpack rootfs> <rootfs> [--version <version of WSL>]
+```
+
+For example:
+
+```
 > wsl.exe --import Ubuntu20.04.3 .\wsl\ .\Downloads\focal-server-cloudimg-amd64-wsl.rootfs.tar.gz --version 2
-</pre>
-		</dd>
-		<dd>Verify that the	image has been imported by running the following command:
-<pre>
+```
+
+Verify that the image has been imported by running the following command:
+
+```
 > wsl.exe --list --all --verbose
 NAME             STATE           VERSION
 *Ubuntu          Running         2
@@ -48,68 +42,61 @@ Ubuntu20.04.3    Stopped         2
 Ubuntu-Preview   Stopped         2
 Ubuntu-20.04     Stopped         2
 TestUbuntuWSL    Stopped         2
-</pre>
-		</dd>
-		<dd>Check the the name used in previous command appears in the list.</dd>
+```
 
-	<dt>Launch the newly installed application
-	    </dt>
-	    <dd>
-<pre>
+Check the the name used in previous command appears in the list.
+
+**Launch the newly installed application**
+
+```
 > wsl -d Ubuntu20.04.3
-</pre>
-	    </dd>
-		<dd>Verify that	you're inside the WSL instance and running the right distribution. For example run:
-<pre>
+```
+
+Verify that you're inside the WSL instance and running the right distribution. For example run:
+
+```
 $ lsb_release -a
 No LSB modules are available.
 Distributor ID: Ubuntu
 Description:    Ubuntu 20.04.3 LTS
 Release:        20.04
 Codename:       focal
-</pre>
-		</dd>
+```
 
-	<dt>Since Jammy (22.04) systemd is also enabled by default, so make sure it's running and that there are no
-		failed units:
-	    </dt>
-	    <dd>
-<pre>
+**Since Jammy (22.04) systemd is also enabled by default, so make sure it's running and that there are no
+failed units:**
+
+```
 $ systemctl is-system-running
 running
 $ systemctl --failed
   UNIT LOAD ACTIVE SUB DESCRIPTION
 
   0 loaded units listed.
-</pre>
-	    </dd>
+```
 
-    <dt>Wait for cloud-init to finish its job, if it's present in the system (cloud-init is only present in recent releases):
-        </dt>
-        <dd>
-<pre>
+**Wait for cloud-init to finish its job, if it's present in the system (cloud-init is only present in recent releases):**
+
+```
 $ which cloud-init && cloud-init status --wait
 /usr/bin/cloud-init
 
 status: disabled
-</pre>
-        </dd>
+```
 
-  <dt>Since the image	has been installed directly and not with the distro launcher, you're logged in a root by default and have to create a first user manually. But first, verify that there is no other user already created by default:
-      </dt>
-      <dd>
-<pre>
+**Since the image has been installed directly and not with the distro launcher, you're logged in a root by default and have to create a first user manually. But first, verify that there is no other user already created by default:**
+
+```
 $ id 1000
 id: '1000': no such user: No such file or directory
 $ id ubuntu
 id: 'ubuntu': no such user
 $ egrep ':100[0-9]:' /etc/passwd        # should output nothing.
-</pre>
-      </dd>
-    <dt>Create a new user named 'ubuntu':
-        </dt>
-        <dd>
-<pre>
+```
+
+**Create a new user named 'ubuntu':**
+
+```
 $ adduser ubuntu
 Adding user `ubuntu' ...
 Adding new group `ubuntu' (1000) ...
@@ -127,35 +114,32 @@ Work Phone []:
 Home Phone []:
 Other []:
 Is the information correct? [Y/n]
-</pre>
-        </dd>
+```
 
-	<dt>Add the newly created user to the sudo group:
-	    </dt>
-	    <dd>
-<pre>
+**Add the newly created user to the sudo group:**
+
+```
 $ usermod -aG sudo ubuntu
-</pre>
-	    </dd>
-	<dd>Verify that you	can switch to the new user
-<pre>
+```
+
+Verify that you can switch to the new user:
+
+```
 $ su ubuntu
-To run a command as administrator (user &quot;root&quot;), use &quot;sudo &lt;command&gt;&quot;.
-See &quot;man sudo_root&quot; for details.
+To run a command as administrator (user "root"), use "sudo <command>".
+See "man sudo_root" for details.
 $ whoami
 ubuntu
-</pre>
-	</dd>
+```
 
-	<dt>Exit WSL. Type CTRL+D twice until you're back to the PowerShell prompt.</dt>
+**Exit WSL.** Type CTRL+D twice until you're back to the PowerShell prompt.
 
-	<dt>Start a WSL	session directly with the newly created user.
-	    </dt>
-	    <dd>
-<pre>
-&gt; wsl -d Ubuntu20.04.3 -u ubuntu
-To run a command as administrator (user &quot;root&quot;), use &quot;sudo &lt;command&gt;&quot;.
-See &quot;man sudo_root&quot; for details.
+**Start a WSL session directly with the newly created user.**
+
+```
+> wsl -d Ubuntu20.04.3 -u ubuntu
+To run a command as administrator (user "root"), use "sudo <command>".
+See "man sudo_root" for details.
 
 Welcome to Ubuntu 20.04.3 LTS (GNU/Linux 5.10.43.3-microsoft-standard-WSL2 x86_64)
 
@@ -176,69 +160,76 @@ To see these additional updates run: apt list --upgradable
 This message is shown once a day. To disable it please create the
 /home/ubuntu/.hushlogin file.
 ubuntu@WSL:/mnt/c/Users/ubuntu$
-</pre>
-	    </dd>
+```
 
-	<dt>Run a command as root with sudo, for instance
-	    </dt>
-	    <dd>
-		<pre>$ sudo apt update</pre>
-	    </dd>
-		<dd>Verify that the	command ends successfully</dd>
+**Run a command as root with sudo, for instance**
 
-	<dt>Apply any update
-	    </dt>
-	    <dd>
-		<pre>$ sudo apt full-upgrade</pre>
-	    </dd>
-		<dd>Verify that the	command ends successfully and that any packge that must be upgraded has been upgraded</dd>
+```
+$ sudo apt update
+```
 
-	<dt>Install a package
-	    </dt>
-	    <dd>
-		<pre>$ sudo apt install hello</pre>
-	    </dd>
-		<dd>Verify that the	package has been successfully installed and the application can run<dd>
-<pre>
+Verify that the command ends successfully.
+
+**Apply any update**
+
+```
+$ sudo apt full-upgrade
+```
+
+Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
+
+**Install a package**
+
+```
+$ sudo apt install hello
+```
+
+Verify that the package has been successfully installed and the application can run:
+
+```
 $ hello
 Hello, world!
-</pre></dd>
+```
 
-	<dt>Install and run graphical applications
-	    </dt>
-	    <dd>
-<pre>
+**Install and run graphical applications**
+
+```
 $ sudo apt install x11-apps gtk-4-examples              # gtk-3-examples for focal
 [...]
-</pre>
-	    </dd>
-		<dd>Start one of the graphical application from the x11-apps package, like xcalc for example:
-<pre>
+```
+
+Start one of the graphical application from the x11-apps package, like xcalc for example:
+
+```
 $ xcalc
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the default backend:
-<pre>
+Start the GTK demo application with the default backend:
+
+```
 $ gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the Wayland backend:
-<pre>
+Start the GTK demo application with the Wayland backend:
+
+```
 $ GDK_BACKEND=wayland gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-	<dt>Check that Windows interoperability is still working
-	</dt>
-		<dd> Launch a Windows application
-<pre>
+**Check that Windows interoperability is still working**
+
+Launch a Windows application:
+
+```
 > notepad.exe # It should open.
-</pre>
-		</dd>
-		<dd> List the contents of the C:\Windows
-<pre>
+```
+
+List the contents of the `C:\Windows`:
+
+```
 > ls -l /mnt/c/Windows
 dr-xr-xr-x 1 root root     512 Feb 11 08:58  AppReadiness
 dr-xr-xr-x 1 root root     512 Apr  1  2024  Boot
@@ -246,42 +237,39 @@ dr-xr-xr-x 1 root root     512 Apr  1  2024  Branding
 dr-xr-xr-x 1 root root     512 Oct  7 14:37  BrowserCore
 dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 [...]
-</pre>
-		</dd>
+```
 
-<dt>Exit WSL
-    </dt>
-    <dd>
-<pre>logout</pre>
-    </dd>
-	<dd>Check that your back to the PowerShell prompt</dd>
+**Exit WSL**
 
-	<dt>Unregister the distro instance
-	    </dt>
-	    <dd>
-<pre>
+```
+logout
+```
+
+Check that your back to the PowerShell prompt.
+
+**Unregister the distro instance**
+
+```
 > wsl.exe --unregister Ubuntu20.04.3
-</pre>
-	    </dd>
-		<dd>The application	is no longer listed
-<pre>
+```
+
+The application is no longer listed:
+
+```
 > wsl --list
 Windows Subsystem for Linux Distributions:
 Ubuntu (Default)
 Ubuntu-Preview
 Ubuntu-20.04
 TestUbuntuWSL
-</pre>
-		</dd>
+```
 
-		<dd>And the directory is either missing or empty.
-<pre>
-&gt; ls .\wsl
-&gt;
-</pre>
-		</dd>
-</dl>
+And the directory is either missing or empty:
 
-<strong>If all actions produce the expected results listed, please <a href="results#add_result">submit</a> a 'passed' result.
-    If an action fails, or produces an unexpected result, please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include the bug number when you <a href="results#add_result">submit</a> your result.</strong>
+```
+> ls .\wsl
+>
+```
 
+**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
+If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**

--- a/stonking/testsuites/WSL/Mandatory/WSL Import and run.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL Import and run.md
@@ -230,7 +230,7 @@ $ sudo apt install x11-apps gtk-4-examples              # gtk-3-examples for foc
 [...]
 ```
 
-Start one of the graphical application from the x11-apps package, like xcalc for example:
+Start one of the graphical applications from the x11-apps package, like xcalc for example:
 
 ```
 $ xcalc

--- a/stonking/testsuites/WSL/Mandatory/WSL cloud-init.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL cloud-init.md
@@ -166,7 +166,7 @@ $ hello
 Hello, world!
 ```
 
-Start one of the graphical application from the x11-apps package, like xcalc for example:
+Start one of the graphical applications from the x11-apps package, like xcalc for example:
 
 ```
 $ xcalc

--- a/stonking/testsuites/WSL/Mandatory/WSL cloud-init.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL cloud-init.md
@@ -1,6 +1,6 @@
 This case tests provisioning tar-based WSL image with relevant cloud-config user data.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/stonking/testsuites/WSL/Mandatory/WSL cloud-init.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL cloud-init.md
@@ -40,7 +40,11 @@ write_files:
     [user]
     default=ubuntu
 
-packages: [hello, x11-apps, gtk-4-examples]
+packages:
+  - x11-apps
+  - gtk-4-examples
+  - snap:
+    - hello
 ```
 
 **Install a new instance from the image you downloaded**
@@ -154,7 +158,8 @@ Verify that the command ends successfully and that any package that must be upgr
 
 **CLI and graphical applications installed by cloud-init**
 
-Verify that the "hello" package has been successfully installed and the application can run:
+Verify that the "hello" package has been successfully installed and the application can run
+(If `/snap/bin` is not automatically added to your `PATH` then run `source /etc/profile`):
 
 ```
 $ hello
@@ -188,6 +193,24 @@ It's possible that it fails due [this WSL bug](https://github.com/microsoft/WSL/
 $ GDK_BACKEND=wayland XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir gtk4-demo
 (Wait a moment until the application starts and is displayed)
 ```
+
+**Install a snap package manually**
+
+Try a graphical snap such as `gnome-system-monitor`:
+
+```
+sudo snap install gnome-system-monitor
+gnome-system-monitor
+gnome-system-monitor
+libpxbackend-1.0.so: cannot open shared object file: No such file or directory
+Failed to load module: /home/user/snap/gnome-system-monitor/common/.cache/gio-modules/libgiolibproxy.so
+
+(gnome-system-monitor:6963): Gtk-WARNING **: 16:02:47.323: Trying to measure GtkButton 0x5757299c71e0 for width of 80, but it needs at least 88
+
+(gnome-system-monitor:6963): Gtk-CRITICAL **: 16:02:47.324: Allocation width too small. Tried to allocate 80x31, but GtkButton 0x5757299c71e0 needs at least 88x31.
+```
+
+_Some warnings may show up, the exact ones may depend on the application and version, but the window should render correctly and be functional_.
 
 **Check that Windows interoperability is still working**
 

--- a/stonking/testsuites/WSL/Mandatory/WSL cloud-init.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL cloud-init.md
@@ -1,6 +1,6 @@
 This case tests provisioning tar-based WSL image with relevant cloud-config user data.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.5.7 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/stonking/testsuites/WSL/Mandatory/WSL cloud-init.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL cloud-init.md
@@ -1,30 +1,29 @@
-<p>This case tests provisioning tar-based WSL image with relevant cloud-config user data.</p>
+This case tests provisioning tar-based WSL image with relevant cloud-config user data.
 
 It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
 
-Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at <a href="https://cdimages.ubuntu.com/ubuntu-wsl/">https://cdimages.ubuntu.com/ubuntu-wsl/</a>
+Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".
 
-For example for latest noble image:  <a href="https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl">https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/noble/pending/noble-wsl-amd64.wsl</a>
+For example for latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
 Make sure to download the image matching the correct release under test from the download link associated to this test case.
 
 Those images have cloud-init seeded. To make sure your environment doesn't contain any files that could
 cause cloud-init to change the expected results of this test cases, empty the following directories on the
 host (Windows) filesystem (if they exist):
 
-<ul>
-	<li>%USERPROFILE%\.cloud-init</li>
-	<li>%USERPROFILE%\.ubuntupro\cloud-init</li>
-</ul>
+- `%USERPROFILE%\.cloud-init`
+- `%USERPROFILE%\.ubuntupro\cloud-init`
 
 After downloading the image, open PowerShell and execute the test case below:
 
-<dl>
-	<dt>Prepare the user data file</dt>
-	<dd>Open a text editor of your choice, create a new file with the following contents and save it as
-		<code>%USERPROFILE%\.cloud-init\Ubuntu-24.04.user-data</code> (adjust the filename to match the
-		release version under test, here assumed to be noble):
-<pre>
+**Prepare the user data file**
+
+Open a text editor of your choice, create a new file with the following contents and save it as
+`%USERPROFILE%\.cloud-init\Ubuntu-24.04.user-data` (adjust the filename to match the
+release version under test, here assumed to be noble):
+
+```
 #cloud-config
 locale: en_GB
 users:
@@ -42,33 +41,37 @@ write_files:
     default=ubuntu
 
 packages: [hello, x11-apps, gtk-4-examples]
-</pre>
-	</dd>
-	<dt>Install a new instance from the image you downloaded
-	    </dt>
-	    <dd>
-<pre>
+```
+
+**Install a new instance from the image you downloaded**
+
+```
 > wsl.exe --install --from-file .\noble-wsl-amd64.wsl
-</pre>
-	    </dd>
-		<dd>Verify that the new instance has been registered by running the following command:
-<pre>
+```
+
+Verify that the new instance has been registered by running the following command:
+
+```
 > wsl.exe --list --all --verbose
 NAME             STATE           VERSION
 *Ubuntu          Running         2
 Ubuntu-24.04     Stopped         2
 Ubuntu-20.04     Stopped         2
 TestUbuntuWSL    Stopped         2
-</pre></dd>
+```
 
-	<dt>Launch the new instance.</dt>
-	<dd>On the Windows Start Menu open the Windows Terminal. When open, at the top, at the right side of
-		the new tab button, click on the dropdown and select the "Ubuntu-24.04" profile. A new tab
-		will appear.</dd>
-	<dd>The provisioning (OOBE) command will run and eventually will run a shell
-		with the user described in the user data file logged in.</dd>
-		<dd>In the example below the Windows user name is ubuntu
-<pre>
+**Launch the new instance.**
+
+On the Windows Start Menu open the Windows Terminal. When open, at the top, at the right side of
+the new tab button, click on the dropdown and select the "Ubuntu-24.04" profile. A new tab
+will appear.
+
+The provisioning (OOBE) command will run and eventually will run a shell
+with the user described in the user data file logged in.
+
+In the example below the Windows user name is ubuntu:
+
+```
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 To run a command as administrator (user "root"), use "sudo <command>".
@@ -90,86 +93,113 @@ Welcome to Ubuntu 24.04.2 LTS (GNU/Linux 5.15.167.4-microsoft-standard-WSL2 x86_
 This message is shown once a day. To disable it please create the
 /home/ubuntu/.hushlogin file.
 ubuntu@mib01:/mnt/c/Users/ubuntu$
-</pre></dd>
-		<dd>Read through the entire message of the day. Make sure there is no warnings nor errors coming from
-			cloud-init</dd>
-		<dd>Verify that the background and foreground colors match the Ubuntu colors and the terminal
-		icon is the Ubuntu logo.</dd>
-		<dd>Verify that the text is rendered with the Ubuntu font.</dd>
-		<dd>Verify that	you're running the right distribution (point) release. For example run:
-<pre>
+```
+
+Read through the entire message of the day. Make sure there is no warnings nor errors coming from
+cloud-init.
+
+Verify that the background and foreground colors match the Ubuntu colors and the terminal
+icon is the Ubuntu logo.
+
+Verify that the text is rendered with the Ubuntu font.
+
+Verify that you're running the right distribution (point) release. For example run:
+
+```
 $ lsb_release -a
 No LSB modules are available.
 Distributor ID: Ubuntu
 Description:    Ubuntu 24.04.2 LTS
 Release:        24.04
 Codename:       noble
-</pre> </dd>
+```
 
-	<dt>Check systemd status</dt>
-		<dd>Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
-<pre>
+**Check systemd status**
+
+Tar-based images have systemd enabled by default, so make sure it's running and that there are no failed units:
+
+```
 $ systemctl is-system-running
 running
 $ systemctl --failed
   UNIT LOAD ACTIVE SUB DESCRIPTION
 
   0 loaded units listed.
-</pre></dd>
+```
 
-	<dt>The default user</dt>
-		<dd>You should be logged in with the user that you just created
-<pre>
+**The default user**
+
+You should be logged in with the user that you just created:
+
+```
 $ whoami
 ubuntu
-</pre></dd>
-		<dd>Run a command as root with sudo, for instance
-<pre>$ sudo apt update</pre></dd>
-		<dd>Verify that the command ends successfully</dd>
-		<dd>Apply any update
-<pre>$ sudo apt full-upgrade</pre></dd>
-		<dd>Verify that the command ends successfully and that any packge that must be upgraded has been upgraded</dd>
+```
 
-	<dt>CLI and graphical applications installed by cloud-init</dt>
-		<dd>Verify that the "hello" package has been successfully installed and the application can run
-<pre>
+Run a command as root with sudo, for instance:
+
+```
+$ sudo apt update
+```
+
+Verify that the command ends successfully.
+
+Apply any update:
+
+```
+$ sudo apt full-upgrade
+```
+
+Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
+
+**CLI and graphical applications installed by cloud-init**
+
+Verify that the "hello" package has been successfully installed and the application can run:
+
+```
 $ hello
 Hello, world!
-</pre></dd>
-		<dd>Start one of the graphical application from the x11-apps package, like xcalc for example:
-<pre>
+```
+
+Start one of the graphical application from the x11-apps package, like xcalc for example:
+
+```
 $ xcalc
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the default backend:
-<pre>
+Start the GTK demo application with the default backend:
+
+```
 $ gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre></dd>
+```
 
-		<dd>Start the GTK demo application with the Wayland backend:
-<pre>
+Start the GTK demo application with the Wayland backend:
+
+```
 $ GDK_BACKEND=wayland gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre>
-		It's possible that it fails due <a href="https://github.com/microsoft/WSL/issues/11261">this
-			WSL bug</a>. To confirm that try again with a different XDG_RUNTIME_DIR as below:
-<pre>
+```
+
+It's possible that it fails due [this WSL bug](https://github.com/microsoft/WSL/issues/11261). To confirm that try again with a different XDG_RUNTIME_DIR as below:
+
+```
 $ GDK_BACKEND=wayland XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir gtk4-demo
 (Wait a moment until the application starts and is displayed)
-</pre>
-		</dd>
+```
 
-	<dt>Check that Windows interoperability is still working
-	</dt>
-		<dd> Launch a Windows application
-<pre>
+**Check that Windows interoperability is still working**
+
+Launch a Windows application:
+
+```
 > notepad.exe # It should open.
-</pre>
-		</dd>
-		<dd> List the contents of the C:\Windows
-<pre>
+```
+
+List the contents of the `C:\Windows`:
+
+```
 > ls -l /mnt/c/Windows
 dr-xr-xr-x 1 root root     512 Feb 11 08:58  AppReadiness
 dr-xr-xr-x 1 root root     512 Apr  1  2024  Boot
@@ -177,35 +207,31 @@ dr-xr-xr-x 1 root root     512 Apr  1  2024  Branding
 dr-xr-xr-x 1 root root     512 Oct  7 14:37  BrowserCore
 dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 [...]
-</pre>
-		</dd>
+```
 
-	<dt>Exit WSL
-	    </dt>
-	    <dd>
-<pre>logout</pre>
-	    </dd>
-		<dd>Check that your back to the PowerShell prompt</dd>
+**Exit WSL**
 
-	<dt>Unregister the distro instance
-	    </dt>
-	    <dd>
-<pre>
+```
+logout
+```
+
+Check that your back to the PowerShell prompt.
+
+**Unregister the distro instance**
+
+```
 > wsl.exe --unregister Ubuntu-24.04
-</pre>
-	    </dd>
-		<dd>The instance is no longer listed
-<pre>
+```
+
+The instance is no longer listed:
+
+```
 > wsl --list
 Windows Subsystem for Linux Distributions:
 Ubuntu (Default)
 Ubuntu-20.04
 TestUbuntuWSL
-</pre></dd>
+```
 
-</dl>
-
-<strong>If all actions produce the expected results listed, please <a href="results#add_result">submit</a> a 'passed' result.
-    If an action fails, or produces an unexpected result, please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include the bug number when you <a href="results#add_result">submit</a> your result.</strong>
-
-
+**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
+If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**

--- a/stonking/testsuites/WSL/Mandatory/WSL cloud-init.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL cloud-init.md
@@ -233,5 +233,9 @@ Ubuntu-20.04
 TestUbuntuWSL
 ```
 
-**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
-If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**
+---- 
+
+**If all actions produce the expected results listed, please submit a `passed` result.** 
+
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**
+

--- a/stonking/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
@@ -1,6 +1,6 @@
 This case tests provisioning a tar-based WSL image as WSL 1.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.5.7 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/stonking/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
@@ -115,7 +115,7 @@ $ sudo apt full-upgrade
 
 Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
 
-Install a package:
+**Install a package:**
 
 ```
 $ sudo apt install hello

--- a/stonking/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
@@ -1,6 +1,6 @@
 This case tests provisioning a tar-based WSL image as WSL 1.
 
-It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
+It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Instructions about how to install Windows and enable WSL 2 is outside of the scope of this document.
 
 Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".

--- a/stonking/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
@@ -1,11 +1,11 @@
-<p>This case tests provisioning a tar-based WSL image as WSL 1.</p>
+This case tests provisioning a tar-based WSL image as WSL 1.
 
 It requires a working Microsoft Windows 11 or higher installation with WSL version 2.4.10 or later. Installing Windows and enabling WSL 2 is outside of the scope of this  test case.
 
-Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at <a href="https://cdimages.ubuntu.com/ubuntu-wsl/">https://cdimages.ubuntu.com/ubuntu-wsl/</a>
+Since the release of Ubuntu LTS 24.04.2 Noble Numbat, tar-based images are found at [https://cdimages.ubuntu.com/ubuntu-wsl/](https://cdimages.ubuntu.com/ubuntu-wsl/)
 and their file extension is ".wsl" instead of ".tar.gz".
 
-For example for latest noble image:  <a href="https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl">https://cdimages.ubuntu.com/ubuntu-wsl/daily-live/noble/pending/noble-wsl-amd64.wsl</a>
+For example for latest noble image:  [https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl](https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/pending/noble-wsl-amd64.wsl)
 Make sure to download the image matching the correct release under test from the download link associated to this test case.
 
 WSL 1 doesn't support systemd, thus we skip checking if its running, if there are failed units. We also assume
@@ -13,39 +13,45 @@ cloud-init cannot run under such environment.
 
 After downloading the image, open PowerShell and follow the steps below:
 
-<dl>
-	<dt>Install a new instance as WSL 1</dt>
-		<dd>Navigate to the folder where you downloaded the image into and enter the following
-				command, adjusting to the correct release name under test
-<pre>
-&gt; wsl --install --from-file .\noble-wsl-amd64.wsl --location .\Noble --name Noble --version 1
-</pre>
-		</dd>
-		<dd>Verify that the new instance has been registered as WSL 1 by running the following command:
-<pre>
+**Install a new instance as WSL 1**
+
+Navigate to the folder where you downloaded the image into and enter the following
+command, adjusting to the correct release name under test:
+
+```
+> wsl --install --from-file .\noble-wsl-amd64.wsl --location .\Noble --name Noble --version 1
+```
+
+Verify that the new instance has been registered as WSL 1 by running the following command:
+
+```
 > wsl.exe --list --all --verbose
 NAME             STATE           VERSION
 *Ubuntu          Running         2
 Noble            Stopped         1
 Ubuntu-20.04     Stopped         2
 TestUbuntuWSL    Stopped         2
-</pre>
-		</dd>
-		<dd>Check the **name** used in previous command appears in the list.</dd>
+```
 
-	<dt>Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
-		the new user creation. The input line should be prefilled with a user name derived from the
-		current Windows user name.</dt>
-		<dd>In the example below the Windows user name is ubuntu
-<pre>
+Check the **name** used in previous command appears in the list.
+
+**Launch the new instance. The provisioning (OOBE) command will run and eventually will prompt for
+the new user creation. The input line should be prefilled with a user name derived from the
+current Windows user name.**
+
+In the example below the Windows user name is ubuntu:
+
+```
 > wsl -d Noble
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
-</pre></dd>
-	<dd>Hit enter and proceed with the default user creation. Once done you should be running bash inside
-	the distro instance
-<pre>
+```
+
+Hit enter and proceed with the default user creation. Once done you should be running bash inside
+the distro instance:
+
+```
 Provisioning the new WSL instance Ubuntu-24.04
 This might take a while...
 Create a default Unix user account: ubuntu
@@ -71,47 +77,68 @@ Welcome to Ubuntu 24.04.2 LTS (GNU/Linux 5.15.167.4-microsoft-standard-WSL2 x86_
 This message is shown once a day. To disable it please create the
 /home/ubuntu/.hushlogin file.
 ubuntu@mib01:/mnt/c/Users/ubuntu$
-</pre></dd>
+```
 
-		<dd>Verify that	you're running the right distribution (point) release. For example run:
-<pre>
+Verify that you're running the right distribution (point) release. For example run:
+
+```
 $ lsb_release -a
 No LSB modules are available.
 Distributor ID: Ubuntu
 Description:    Ubuntu 24.04.2 LTS
 Release:        24.04
 Codename:       noble
-</pre> </dd>
+```
 
-	<dt>The default user</dt>
-		<dd>You should be logged in with the user that you just created
-<pre>
+**The default user**
+
+You should be logged in with the user that you just created:
+
+```
 $ whoami
 ubuntu
-</pre></dd>
-		<dd>Run a command as root with sudo, for instance
-<pre>$ sudo apt update</pre></dd>
-		<dd>Verify that the command ends successfully</dd>
-		<dd>Apply any update
-<pre>$ sudo apt full-upgrade</pre></dd>
-		<dd>Verify that the command ends successfully and that any packge that must be upgraded has been upgraded</dd>
-		<dd>Install a package
-<pre>$ sudo apt install hello</pre></dd>
-		<dd>Verify that the package has been successfully installed and the application can run
-<pre>
+```
+
+Run a command as root with sudo, for instance:
+
+```
+$ sudo apt update
+```
+
+Verify that the command ends successfully.
+
+Apply any update:
+
+```
+$ sudo apt full-upgrade
+```
+
+Verify that the command ends successfully and that any package that must be upgraded has been upgraded.
+
+Install a package:
+
+```
+$ sudo apt install hello
+```
+
+Verify that the package has been successfully installed and the application can run:
+
+```
 $ hello
 Hello, world!
-</pre></dd>
+```
 
-	<dt>Check that Windows interoperability is still working
-	</dt>
-		<dd> Launch a Windows application
-<pre>
+**Check that Windows interoperability is still working**
+
+Launch a Windows application:
+
+```
 > notepad.exe # It should open.
-</pre>
-		</dd>
-		<dd> List the contents of the C:\Windows
-<pre>
+```
+
+List the contents of the `C:\Windows`:
+
+```
 > ls -l /mnt/c/Windows
 dr-xr-xr-x 1 root root     512 Feb 11 08:58  AppReadiness
 dr-xr-xr-x 1 root root     512 Apr  1  2024  Boot
@@ -119,35 +146,31 @@ dr-xr-xr-x 1 root root     512 Apr  1  2024  Branding
 dr-xr-xr-x 1 root root     512 Oct  7 14:37  BrowserCore
 dr-xr-xr-x 1 root root     512 Jun  4  2024  CSCmnt
 [...]
-</pre>
-		</dd>
+```
 
-	<dt>Exit WSL
-	    </dt>
-	    <dd>
-<pre>logout</pre>
-	    </dd>
-		<dd>Check that your back to the PowerShell prompt</dd>
+**Exit WSL**
 
-	<dt>Unregister the distro instance
-	    </dt>
-	    <dd>
-<pre>
+```
+logout
+```
+
+Check that your back to the PowerShell prompt.
+
+**Unregister the distro instance**
+
+```
 > wsl.exe --unregister Noble
-</pre>
-	    </dd>
-		<dd>The isntance no longer listed
-<pre>
+```
+
+The instance no longer listed:
+
+```
 > wsl --list
 Windows Subsystem for Linux Distributions:
 Ubuntu (Default)
 Ubuntu-20.04
 TestUbuntuWSL
-</pre></dd>
+```
 
-</dl>
-
-<strong>If all actions produce the expected results listed, please <a href="results#add_result">submit</a> a 'passed' result.
-    If an action fails, or produces an unexpected result, please <a href="results#add_result">submit</a> a 'failed' result and <a href="../../buginstructions">file a bug</a>. Please be sure to include the bug number when you <a href="results#add_result">submit</a> your result.</strong>
-
-
+**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
+If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**

--- a/stonking/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
+++ b/stonking/testsuites/WSL/Mandatory/WSL_Tar Format on WSL1.md
@@ -172,5 +172,8 @@ Ubuntu-20.04
 TestUbuntuWSL
 ```
 
-**If all actions produce the expected results listed, please [submit](results#add_result) a 'passed' result.
-If an action fails, or produces an unexpected result, please [submit](results#add_result) a 'failed' result and [file a bug](../../buginstructions). Please be sure to include the bug number when you [submit](results#add_result) your result.**
+---- 
+
+**If all actions produce the expected results listed, please submit a `passed` result.** 
+
+**If an action fails, or produces an unexpected result, please submit a `failed` result and file a bug. Please be sure to include the bug number when you submit your result.**


### PR DESCRIPTION
Existing contents for WSL still use the outdated HTML templating format. This PR migrates the format to Markdown in alignment with other existing test cases/products, better aligns repeated requirements across multiple files and updates assumptions related to WSL version.

For example, installing a tar-based distro used to be a two step action, where the user would first issue an install command (via CLI or double clicking an image file) and then launch the instance with `wsl.exe -d <INSTANCE>`. It's been a while since WSL automatically launches the distro instance upon installation.

Finally this PR adds steps related to installing and running snap packages when possible (WSL1 cannot).

---

UDENG-9872